### PR TITLE
Patch currently applied to the Debian package

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -4,12 +4,12 @@ OS = $(shell uname)
 ARCH = $(shell uname -m)
 
 FC = gfortran
-FFLAGS = -O3
+FFLAGS += -O3
 
 USEGCC = 1
 USECLANG = 0
 
-CFLAGS= -std=c99 -Wall -O3 -I$(OPENLIBM_HOME) -I$(OPENLIBM_HOME)/include -I$(OPENLIBM_HOME)/ld80 -I$(OPENLIBM_HOME)/$(ARCH) -I$(OPENLIBM_HOME)/src -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration
+CFLAGS += -std=c99 -Wall -O3 -I$(OPENLIBM_HOME) -I$(OPENLIBM_HOME)/include -I$(OPENLIBM_HOME)/ld80 -I$(OPENLIBM_HOME)/$(ARCH) -I$(OPENLIBM_HOME)/src -DASSEMBLER -D__BSD_VISIBLE -Wno-implicit-function-declaration
 
 ifeq ($(USECLANG),1)
 USEGCC = 0
@@ -25,7 +25,7 @@ endif
 default: all
 
 %.c.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 %.f.o: %.f
 	$(FC) $(FFLAGS) -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: libopenlibm.a libopenlibm.$(SHLIB_EXT)
 libopenlibm.a: $(OBJS)  
 	ar -rcs libopenlibm.a $(OBJS)
 libopenlibm.$(SHLIB_EXT): $(OBJS)
-	$(FC) -shared $(OBJS) -o libopenlibm.$(SHLIB_EXT)
+	$(FC) -shared $(OBJS) $(LDFLAGS) -o libopenlibm.$(SHLIB_EXT)
 
 distclean:
 	rm -f $(OBJS) *.a *.$(SHLIB_EXT)


### PR DESCRIPTION
Injecting CPPFLAGS/CFLAGS/CXXFLAGS/FFLAGS/LDFLAGS everywhere is important for Debian, in order to enable hardening (see http://wiki.debian.org/Hardening )
