### PR TITLE
Use --noexecstack for assembly code

### DIFF
--- a/amd64/e_remainder.S
+++ b/amd64/e_remainder.S
@@ -24,3 +24,7 @@ ENTRY(remainder)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/e_remainderf.S
+++ b/amd64/e_remainderf.S
@@ -23,3 +23,7 @@ ENTRY(remainderf)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/e_remainderl.S
+++ b/amd64/e_remainderl.S
@@ -29,3 +29,7 @@ ENTRY(remainderl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/e_sqrt.S
+++ b/amd64/e_sqrt.S
@@ -34,3 +34,7 @@ END(sqrt)
 
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/e_sqrtf.S
+++ b/amd64/e_sqrtf.S
@@ -33,3 +33,7 @@ ENTRY(sqrtf)
 END(sqrtf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/e_sqrtl.S
+++ b/amd64/e_sqrtl.S
@@ -40,3 +40,7 @@ ENTRY(sqrtl)
 #endif
 	ret
 
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_llrint.S
+++ b/amd64/s_llrint.S
@@ -6,3 +6,7 @@ ENTRY(llrint)
 	ret
 END(llrint)
 
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_llrintf.S
+++ b/amd64/s_llrintf.S
@@ -6,3 +6,7 @@ ENTRY(llrintf)
 	ret
 END(llrintf)
 
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_llrintl.S
+++ b/amd64/s_llrintl.S
@@ -39,3 +39,7 @@ ENTRY(llrintl)
 	ret
 
 
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_logbl.S
+++ b/amd64/s_logbl.S
@@ -23,3 +23,7 @@ ENTRY(logbl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_lrint.S
+++ b/amd64/s_lrint.S
@@ -38,3 +38,7 @@ ENTRY(lrint)
 END(lrint)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_lrintf.S
+++ b/amd64/s_lrintf.S
@@ -38,3 +38,7 @@ ENTRY(lrintf)
 END(lrintf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_lrintl.S
+++ b/amd64/s_lrintl.S
@@ -39,3 +39,7 @@ ENTRY(lrintl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_remquo.S
+++ b/amd64/s_remquo.S
@@ -70,3 +70,7 @@ ENTRY(remquo)
 END(remquo)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_remquof.S
+++ b/amd64/s_remquof.S
@@ -70,3 +70,7 @@ ENTRY(remquof)
 END(remquof)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_remquol.S
+++ b/amd64/s_remquol.S
@@ -75,3 +75,7 @@ ENTRY(remquol)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_rintl.S
+++ b/amd64/s_rintl.S
@@ -20,3 +20,7 @@ ENTRY(rintl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_scalbn.S
+++ b/amd64/s_scalbn.S
@@ -45,3 +45,7 @@ END(scalbn)
 
 .globl CNAME(ldexp)
 .set   CNAME(ldexp),CNAME(scalbn)
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_scalbnf.S
+++ b/amd64/s_scalbnf.S
@@ -47,3 +47,7 @@ END(scalbnf)
 .set	CNAME(ldexpf),CNAME(scalbnf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/s_scalbnl.S
+++ b/amd64/s_scalbnl.S
@@ -32,3 +32,7 @@ END(scalbnl)
 .set	CNAME(ldexpl),CNAME(scalbnl)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_exp.S
+++ b/i387/e_exp.S
@@ -69,3 +69,8 @@ x_not_minus_Inf:
 END(exp)
 
     //
+
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_fmod.S
+++ b/i387/e_fmod.S
@@ -19,3 +19,7 @@ ENTRY(fmod)
 END(fmod)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_log.S
+++ b/i387/e_log.S
@@ -15,3 +15,7 @@ ENTRY(log)
 END(log)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_log10.S
+++ b/i387/e_log10.S
@@ -15,3 +15,7 @@ ENTRY(log10)
 END(log10)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_log10f.S
+++ b/i387/e_log10f.S
@@ -16,3 +16,7 @@ ENTRY(log10f)
 END(log10f)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_logf.S
+++ b/i387/e_logf.S
@@ -15,3 +15,7 @@ ENTRY(logf)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_remainder.S
+++ b/i387/e_remainder.S
@@ -19,3 +19,7 @@ ENTRY(remainder)
 END(remainder)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_remainderf.S
+++ b/i387/e_remainderf.S
@@ -20,3 +20,7 @@ ENTRY(remainderf)
 END(remainderf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_remainderl.S
+++ b/i387/e_remainderl.S
@@ -19,3 +19,7 @@ ENTRY(remainderl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_sqrt.S
+++ b/i387/e_sqrt.S
@@ -14,3 +14,7 @@ ENTRY(sqrt)
 END(sqrt)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_sqrtf.S
+++ b/i387/e_sqrtf.S
@@ -15,3 +15,7 @@ ENTRY(sqrtf)
 END(sqrtf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/e_sqrtl.S
+++ b/i387/e_sqrtl.S
@@ -13,3 +13,7 @@ ENTRY(sqrtl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_ceil.S
+++ b/i387/s_ceil.S
@@ -28,3 +28,7 @@ ENTRY(ceil)
 END(ceil)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_ceilf.S
+++ b/i387/s_ceilf.S
@@ -30,3 +30,7 @@ ENTRY(ceilf)
 END(ceilf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_ceill.S
+++ b/i387/s_ceill.S
@@ -28,3 +28,7 @@ ENTRY(ceill)
 END(ceill)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_copysign.S
+++ b/i387/s_copysign.S
@@ -19,3 +19,7 @@ ENTRY(copysign)
 END(copysign)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_copysignf.S
+++ b/i387/s_copysignf.S
@@ -20,3 +20,7 @@ ENTRY(copysignf)
 END(copysignf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_copysignl.S
+++ b/i387/s_copysignl.S
@@ -18,3 +18,7 @@ ENTRY(copysignl)
 END(copysignl)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_cos.S
+++ b/i387/s_cos.S
@@ -27,3 +27,7 @@ ENTRY(cos)
 END(cos)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_finite.S
+++ b/i387/s_finite.S
@@ -17,3 +17,7 @@ ENTRY(finite)
 END(finite)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_floor.S
+++ b/i387/s_floor.S
@@ -29,3 +29,7 @@ ENTRY(floor)
 END(floor)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_floorf.S
+++ b/i387/s_floorf.S
@@ -30,3 +30,7 @@ ENTRY(floorf)
 END(floorf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_floorl.S
+++ b/i387/s_floorl.S
@@ -28,3 +28,7 @@ ENTRY(floorl)
 END(floorl)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_llrint.S
+++ b/i387/s_llrint.S
@@ -37,3 +37,7 @@ ENTRY(llrint)
 END(llrint)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_llrintf.S
+++ b/i387/s_llrintf.S
@@ -37,3 +37,7 @@ ENTRY(llrintf)
 END(llrintf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_llrintl.S
+++ b/i387/s_llrintl.S
@@ -36,3 +36,7 @@ ENTRY(llrintl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_logb.S
+++ b/i387/s_logb.S
@@ -15,3 +15,7 @@ ENTRY(logb)
 END(logb)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_logbf.S
+++ b/i387/s_logbf.S
@@ -16,3 +16,7 @@ ENTRY(logbf)
 END(logbf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_logbl.S
+++ b/i387/s_logbl.S
@@ -14,3 +14,7 @@ ENTRY(logbl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_lrint.S
+++ b/i387/s_lrint.S
@@ -36,3 +36,7 @@ ENTRY(lrint)
 END(lrint)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_lrintf.S
+++ b/i387/s_lrintf.S
@@ -36,3 +36,7 @@ ENTRY(lrintf)
 END(lrintf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_lrintl.S
+++ b/i387/s_lrintl.S
@@ -35,3 +35,7 @@ ENTRY(lrintl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_remquo.S
+++ b/i387/s_remquo.S
@@ -63,3 +63,7 @@ ENTRY(remquo)
 END(remquo)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_remquof.S
+++ b/i387/s_remquof.S
@@ -63,3 +63,7 @@ ENTRY(remquof)
 END(remquof)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_remquol.S
+++ b/i387/s_remquol.S
@@ -63,3 +63,7 @@ ENTRY(remquol)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_rint.S
+++ b/i387/s_rint.S
@@ -14,3 +14,7 @@ ENTRY(rint)
 END(rint)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_rintf.S
+++ b/i387/s_rintf.S
@@ -15,3 +15,7 @@ ENTRY(rintf)
 END(rintf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_rintl.S
+++ b/i387/s_rintl.S
@@ -13,3 +13,7 @@ ENTRY(rintl)
 	ret
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_scalbn.S
+++ b/i387/s_scalbn.S
@@ -17,3 +17,7 @@ END(scalbn)
 
 .globl CNAME(ldexp)
 .set   CNAME(ldexp),CNAME(scalbn)
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_scalbnf.S
+++ b/i387/s_scalbnf.S
@@ -20,3 +20,7 @@ END(scalbnf)
 .set	CNAME(ldexpf),CNAME(scalbnf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_scalbnl.S
+++ b/i387/s_scalbnl.S
@@ -20,3 +20,7 @@ END(scalbnl)
 .set	CNAME(ldexpl),CNAME(scalbnl)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_significand.S
+++ b/i387/s_significand.S
@@ -15,3 +15,7 @@ ENTRY(significand)
 END(significand)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_significandf.S
+++ b/i387/s_significandf.S
@@ -16,3 +16,7 @@ ENTRY(significandf)
 END(significandf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_sin.S
+++ b/i387/s_sin.S
@@ -27,3 +27,7 @@ ENTRY(sin)
 END(sin)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_tan.S
+++ b/i387/s_tan.S
@@ -29,3 +29,7 @@ ENTRY(tan)
 END(tan)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_trunc.S
+++ b/i387/s_trunc.S
@@ -27,3 +27,7 @@ ENTRY(trunc)
 END(trunc)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_truncf.S
+++ b/i387/s_truncf.S
@@ -27,3 +27,7 @@ ENTRY(truncf)
 END(truncf)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/i387/s_truncl.S
+++ b/i387/s_truncl.S
@@ -27,3 +27,7 @@ ENTRY(truncl)
 END(truncl)
 
 	
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/ia64/s_fma.S
+++ b/ia64/s_fma.S
@@ -33,3 +33,8 @@ ENTRY(fma, 3)
 	br.ret.sptk	b0
 }
 END(fma)
+
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/ia64/s_fmaf.S
+++ b/ia64/s_fmaf.S
@@ -33,3 +33,8 @@ ENTRY(fmaf, 3)
 	br.ret.sptk	b0
 }
 END(fmaf)
+
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/ia64/s_fmal.S
+++ b/ia64/s_fmal.S
@@ -33,3 +33,8 @@ ENTRY(fmal, 3)
 	br.ret.sptk	b0
 }
 END(fmal)
+
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/sparc64/e_sqrt.S
+++ b/sparc64/e_sqrt.S
@@ -31,3 +31,8 @@ ENTRY(sqrt)
 	retl
 	fsqrtd %f0, %f0
 END(sqrt)
+
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/sparc64/e_sqrtf.S
+++ b/sparc64/e_sqrtf.S
@@ -31,3 +31,8 @@ ENTRY(sqrtf)
 	retl
 	fsqrts %f1, %f0
 END(sqrtf)
+
+/* Enable stack protection */
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
This enables hardware stack protection, which is required by distributions.
See https://wiki.gentoo.org/wiki/Project:Hardened/GNU_stack_quickstart

I found this problem when checking my RPM package of Julia.
The other solution suggested by the above page is to add code to every
.S file:
.section .note.GNU-stack,"",%progbits

They consider it a better approach for upstreaming, but AFAICT there
is not difference with always passing the flags, and this avoids
much duplicated blocks in many files.

This seems to be supported on all architectures now (see link), but
I have no idea what happens with compilers other than gcc.
