### PR TITLE
Install bsd_asm.h and bsd_cdefs.h to $(includedir)/openlibm/$(ARCH)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,9 @@ install: all
 	cp -a libopenlibm.$(SHLIB_EXT)* libopenlibm.a $(DESTDIR)$(libdir)/
 	cp -a src/openlibm.h $(DESTDIR)$(includedir)/
 	cp -a include/*.h $(DESTDIR)$(includedir)/openlibm/
+ifneq ($(wildcard $(ARCH)/bsd_asm.h),)
+	cp -a $(ARCH)/bsd_asm.h $(DESTDIR)$(includedir)/openlibm/
+endif
+ifneq ($(wildcard $(ARCH)/bsd_cdefs.h),)
+	cp -a $(ARCH)/bsd_cdefs.h $(DESTDIR)$(includedir)/openlibm/
+endif


### PR DESCRIPTION
@tkelman: is this what you wanted? I have no idea how this can be useful for you on Windows. :-)

I found something weird: `bsd_asm.h` and `bsd_cdefs.h` are only present for amd64 and i387, but the former is referenced by files in `ia64/` and `sparc64/`. Have these architectures been tested at all?
