### PR TITLE
Fix missing includes

### DIFF
--- a/src/s_conj.c
+++ b/src/s_conj.c
@@ -28,6 +28,7 @@
 
 #include <complex.h>
 
+#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT double complex

--- a/src/s_conjf.c
+++ b/src/s_conjf.c
@@ -28,6 +28,7 @@
 
 #include <complex.h>
 
+#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT float complex

--- a/src/s_conjl.c
+++ b/src/s_conjl.c
@@ -28,6 +28,7 @@
 
 #include <complex.h>
 
+#include "openlibm.h"
 #include "math_private.h"
 
 DLLEXPORT long double complex


### PR DESCRIPTION
Last commit made defition of cpack() not available to files
which do not include openlibm.h.
