### PR TITLE
Install libopenlibm.dll to bindir

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -5,6 +5,7 @@ VERSION = 0.2.0
 VERSION_SPLIT = $(subst ., , $(VERSION))
 DESTDIR =
 prefix = /usr/local
+bindir = $(prefix)/bin
 libdir = $(prefix)/lib
 includedir = $(prefix)/include
 
@@ -68,12 +69,16 @@ endif
 ifneq (,$(findstring MINGW,$(OS)))
 override OS=WINNT
 endif
-#keep these if statements these separate
+
+#keep these if statements separate
 ifeq ($(OS), WINNT)
 SHLIB_EXT = dll
 SONAME_FLAG = -soname
-CFLAGS_add+=-nodefaultlibs
-FFLAGS+=-nodefaultlibs
+CFLAGS_add += -nodefaultlibs
+FFLAGS += -nodefaultlibs
+shlibdir = bindir
+else
+shlibdir = libdir
 endif
 
 ifeq ($(OS), Linux)

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,14 @@ all: libopenlibm.a libopenlibm.$(SHLIB_EXT)
 libopenlibm.a: $(OBJS)  
 	$(AR) -rcs libopenlibm.a $(OBJS)
 libopenlibm.$(SHLIB_EXT): $(OBJS)
+ifeq ($(OS),WINNT)
+	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT) -o libopenlibm.$(SHLIB_EXT)
+else
 	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(VERSION) -o libopenlibm.$(SHLIB_EXT).$(VERSION)
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(VERSION) libopenlibm.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT)).$(word 2,$(VERSION_SPLIT))
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(VERSION) libopenlibm.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT))
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(VERSION) libopenlibm.$(SHLIB_EXT)
-
+endif
 
 clean:
 	@for dir in $(SUBDIRS) .; do \
@@ -42,9 +45,11 @@ distclean:
 	-$(MAKE) -C test clean
 
 install: all
+	mkdir -p $(DESTDIR)$(shlibdir)
 	mkdir -p $(DESTDIR)$(libdir)
 	mkdir -p $(DESTDIR)$(includedir)/openlibm
-	cp -a libopenlibm.$(SHLIB_EXT)* libopenlibm.a $(DESTDIR)$(libdir)/
+	cp -a libopenlibm.$(SHLIB_EXT)* $(DESTDIR)$(shlibdir)/
+	cp -a libopenlibm.a $(DESTDIR)$(libdir)/
 	cp -a src/openlibm.h $(DESTDIR)$(includedir)/
 	cp -a include/*.h $(DESTDIR)$(includedir)/openlibm/
 ifneq ($(wildcard $(ARCH)/bsd_asm.h),)


### PR DESCRIPTION
Also skip dll versioning on Windows

This is an alternative to https://github.com/JuliaLang/julia/pull/6459 - if this gets merged here, I'll modify that PR in Julia to stop special-casing the openlibm install rule for Windows. (And include the submodule bump.)
