### PR TITLE
Bump version to 0.3

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1,7 +1,7 @@
 # -*- mode: makefile-gmake -*-
 
 OS := $(shell uname)
-VERSION = 0.2.0
+VERSION = 0.3.0
 VERSION_SPLIT = $(subst ., , $(VERSION))
 DESTDIR =
 prefix = /usr/local


### PR DESCRIPTION
The recent changes make it possible to build openspecfun with
USE_OPENLIBM=1 when openlibm is installed as a system library.
Having a new version will allow me to make an RPM package.
