### PR TITLE
Export ldexp aliases on Windows

### DIFF
--- a/amd64/s_scalbn.S
+++ b/amd64/s_scalbn.S
@@ -41,10 +41,14 @@ ENTRY(scalbn)
 	fstpl	-8(%rsp)
 	movsd	-8(%rsp),%xmm0
 	ret
+#ifndef _WIN64
 END(scalbn)
-
 .globl CNAME(ldexp)
+#else
+.globl CNAME(ldexp); .section .drectve; .ascii " -export:ldexp"
+#endif
 .set   CNAME(ldexp),CNAME(scalbn)
+
 /* Enable stack protection */
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/amd64/s_scalbnf.S
+++ b/amd64/s_scalbnf.S
@@ -41,12 +41,14 @@ ENTRY(scalbnf)
 	fstps	-8(%rsp)
 	movss	-8(%rsp),%xmm0
 	ret
+#ifndef _WIN64
 END(scalbnf)
-
 .globl CNAME(ldexpf)
-.set	CNAME(ldexpf),CNAME(scalbnf)
+#else
+.globl CNAME(ldexpf); .section .drectve; .ascii " -export:ldexpf"
+#endif
+.set   CNAME(ldexpf),CNAME(scalbnf)
 
-	
 /* Enable stack protection */
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/amd64/s_scalbnl.S
+++ b/amd64/s_scalbnl.S
@@ -26,12 +26,14 @@ ENTRY(scalbnl)
     fstpt   (%rcx)
 #endif
 	ret
+#ifndef _WIN64
 END(scalbnl)
+.globl CNAME(ldexpl)
+#else
+.globl CNAME(ldexpl); .section .drectve; .ascii " -export:ldexpl"
+#endif
+.set   CNAME(ldexpl),CNAME(scalbnl)
 
-.globl	CNAME(ldexpl)
-.set	CNAME(ldexpl),CNAME(scalbnl)
-
-	
 /* Enable stack protection */
 #if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits

--- a/include/cdefs-compat.h
+++ b/include/cdefs-compat.h
@@ -22,8 +22,12 @@
 
 #ifdef __GNUC__
 #ifndef __strong_reference
-#define __strong_reference(sym,aliassym)	
-	//extern __typeof (sym) aliassym __attribute__ ((__alias__ (#sym)));
+#ifdef __APPLE__
+#define __strong_reference(sym,aliassym) __weak_reference(sym,aliassym)
+#else
+#define __strong_reference(sym,aliassym)	\
+	DLLEXPORT extern __typeof (sym) aliassym __attribute__ ((__alias__ (#sym)));
+#endif /* __APPLE__ */
 #endif /* __strong_reference */
 
 #ifndef __weak_reference


### PR DESCRIPTION
The existing __strong_reference's in src/s_scalbn_.c are not being found since
those files get skipped in favor of the arch-specific assembly versions.
And on Windows, ldexp_ needs to be defined with a DLLEXPORT to be resolved.

Fixes https://github.com/JuliaLang/julia/issues/6777

This could be made platform-dependent, using a __strong_reference on Unix and this DLLEXPORT version only on Windows, if there are performance implications of these being functions.
