### PR TITLE
Introduce SONAME_VERSION

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -2,6 +2,9 @@
 
 OS := $(shell uname)
 VERSION = 0.3.0
+# This SONAME_VERSION is independent of the major version decimal.
+# It should only be incremented when backwards-incompatible changes are made
+SONAME_VERSION = 0
 VERSION_SPLIT = $(subst ., , $(VERSION))
 DESTDIR =
 prefix = /usr/local

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ libopenlibm.$(SHLIB_EXT): $(OBJS)
 ifeq ($(OS),WINNT)
 	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT) -o libopenlibm.$(SHLIB_EXT)
 else
-	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(VERSION) -o libopenlibm.$(SHLIB_EXT).$(VERSION)
+	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(SONAME_VERSION) -o libopenlibm.$(SHLIB_EXT).$(VERSION)
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(VERSION) libopenlibm.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT)).$(word 2,$(VERSION_SPLIT))
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(VERSION) libopenlibm.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT))
 	@-ln -sf libopenlibm.$(SHLIB_EXT).$(VERSION) libopenlibm.$(SHLIB_EXT)


### PR DESCRIPTION
Use that instead of VERSION for setting the SONAME on non-windows versions

@sebastien-villemot @nalimilan does this satisfy proper SONAME procedures?
