### PR TITLE
Separate SOVERSION from release version

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1,8 +1,11 @@
 # -*- mode: makefile-gmake -*-
 
 OS := $(shell uname)
+# Do not forget to bump SOMINOR when changing VERSION,
+# and SOMAJOR when changing API
 VERSION = 0.4
-VERSION_SPLIT = $(subst ., , $(VERSION))
+SOMAJOR = 1
+SOMINOR = 0
 DESTDIR =
 prefix = /usr/local
 bindir = $(prefix)/bin

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ libopenlibm.$(SHLIB_EXT): $(OBJS)
 ifeq ($(OS),WINNT)
 	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT) -o libopenlibm.$(SHLIB_EXT)
 else
-	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT)) -o libopenlibm.$(SHLIB_EXT).$(VERSION)
-	@-ln -sf libopenlibm.$(SHLIB_EXT).$(VERSION) libopenlibm.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT))
-	@-ln -sf libopenlibm.$(SHLIB_EXT).$(VERSION) libopenlibm.$(SHLIB_EXT)
+	$(CC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenlibm.$(SHLIB_EXT).$(SOMAJOR) -o libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
+	@-ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT).$(SOMAJOR)
+	@-ln -sf libopenlibm.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenlibm.$(SHLIB_EXT)
 endif
 
 clean:


### PR DESCRIPTION
Needed to break API in 0.4 without calling it 1.0.

Cf. https://github.com/JuliaLang/julia/issues/5365 I will do the same for openspecfun in a few hours.
