### PR TITLE
change include path to build on linux, fix .gitignore

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -4,5 +4,6 @@
 /test-double
 /test-double-system
 /test-double.dSYM
-/libm-bench
+/bench-openlibm
+/bench-syslibm
 /*.exe

--- a/test/libm-bench.cpp
+++ b/test/libm-bench.cpp
@@ -3,7 +3,7 @@
 // Benchmark on libm functions
 
 #include <math.h>
-#include <sys/time.h>
+#include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
This fixes the path so that `make bench` will build on linux. In case you're interested, here's the test results:

```
┌─[2]──[Fri Dec 05]──[04:34:31]────────────────────────────────────────
│ simon@julia:~/src/openlibm/test (master *=)
├ ./bench-openlibm 
  pow     :   5.8048 MPS
  hypot   :  34.6305 MPS
  exp     :  43.7774 MPS
  log     :  34.5099 MPS
  log10   :  26.3844 MPS
  sin     :  61.1922 MPS
  cos     :  57.9251 MPS
  tan     :  29.1895 MPS
  asin    :  35.8352 MPS
  acos    :  37.4910 MPS
  atan    :  34.2084 MPS
  atan2   :  16.8578 MPS
┌─[3]──[Fri Dec 05]──[04:34:46]────────────────────────────────────────
│ simon@julia:~/src/openlibm/test (master *=)
├ ./bench-syslibm 
  pow     :   8.2817 MPS
  hypot   :  29.0614 MPS
  exp     :  25.4323 MPS
  log     :  14.7131 MPS
  log10   :  13.6427 MPS
  sin     :  27.8612 MPS
  cos     :  31.5479 MPS
  tan     :  19.3949 MPS
  asin    :  25.3975 MPS
  acos    :  23.8239 MPS
  atan    :  22.2368 MPS
  atan2   :  12.0541 MPS
```
