### PR TITLE
Enable optimization again for *int.c and *intf.c 

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -129,13 +129,6 @@ endif
 endif
 
 
-# *int / *intf need to be built with -O0
-src/%int.c.o: src/%int.c
-	$(CC) $(CPPFLAGS) -O0 $(CFLAGS_add) -c $< -o $@
-
-src/%intf.c.o: src/%intf.c
-	$(CC) $(CPPFLAGS) -O0 $(CFLAGS_add) -c $< -o $@
-
 %.c.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add) -c $< -o $@
 


### PR DESCRIPTION
Optimization was disabled in dcc0d8da7400b68cb0b02c4605ce10fd605f3a1a.  This PR serves as a reminder to enable it again.
