### PR TITLE
Fix compilation of gcc when using openlibm as system libm

### DIFF
--- a/include/openlibm_math.h
+++ b/include/openlibm_math.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef __arm__
-#define LONG_DOUBLE
+#define OPENLIBM_LONG_DOUBLE
 #endif
 
 #ifndef __pure2

--- a/include/openlibm_math.h
+++ b/include/openlibm_math.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef __arm__
-#define OPENLIBM_LONG_DOUBLE
+#define OLM_LONG_DOUBLE
 #endif
 
 #ifndef __pure2

--- a/src/s_fpclassify.c
+++ b/src/s_fpclassify.c
@@ -49,7 +49,7 @@ __fpclassifyd(double d)
 		return FP_SUBNORMAL;
 	}
 }
-		
+
 
 OLM_DLLEXPORT int
 __fpclassifyf(float f)
@@ -72,7 +72,7 @@ __fpclassifyf(float f)
 	}
 }
 
-#ifdef LONG_DOUBLE
+#ifdef OPENLIBM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __fpclassifyl(long double e)
 {
@@ -95,4 +95,3 @@ __fpclassifyl(long double e)
 	}
 }
 #endif
-

--- a/src/s_fpclassify.c
+++ b/src/s_fpclassify.c
@@ -49,7 +49,7 @@ __fpclassifyd(double d)
 		return FP_SUBNORMAL;
 	}
 }
-
+		
 
 OLM_DLLEXPORT int
 __fpclassifyf(float f)
@@ -72,7 +72,7 @@ __fpclassifyf(float f)
 	}
 }
 
-#ifdef OPENLIBM_LONG_DOUBLE
+#ifdef OLM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __fpclassifyl(long double e)
 {
@@ -95,3 +95,4 @@ __fpclassifyl(long double e)
 	}
 }
 #endif
+

--- a/src/s_isfinite.c
+++ b/src/s_isfinite.c
@@ -49,7 +49,7 @@ __isfinitef(float f)
 	return (u.bits.exp != 255);
 }
 
-#ifdef LONG_DOUBLE
+#ifdef OPENLIBM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __isfinitel(long double e)
 {

--- a/src/s_isfinite.c
+++ b/src/s_isfinite.c
@@ -49,7 +49,7 @@ __isfinitef(float f)
 	return (u.bits.exp != 255);
 }
 
-#ifdef OPENLIBM_LONG_DOUBLE
+#ifdef OLM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __isfinitel(long double e)
 {

--- a/src/s_isinf.c
+++ b/src/s_isinf.c
@@ -51,7 +51,7 @@ __isinff(float f)
 	return (u.bits.exp == 255 && u.bits.man == 0);
 }
 
-#ifdef LONG_DOUBLE
+#ifdef OPENLIBM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __isinfl(long double e)
 {

--- a/src/s_isinf.c
+++ b/src/s_isinf.c
@@ -51,7 +51,7 @@ __isinff(float f)
 	return (u.bits.exp == 255 && u.bits.man == 0);
 }
 
-#ifdef OPENLIBM_LONG_DOUBLE
+#ifdef OLM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __isinfl(long double e)
 {

--- a/src/s_isnan.c
+++ b/src/s_isnan.c
@@ -52,7 +52,7 @@ __isnanf(float f)
 	return (u.bits.exp == 255 && u.bits.man != 0);
 }
 
-#ifdef OPENLIBM_LONG_DOUBLE
+#ifdef OLM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __isnanl(long double e)
 {

--- a/src/s_isnan.c
+++ b/src/s_isnan.c
@@ -52,7 +52,7 @@ __isnanf(float f)
 	return (u.bits.exp == 255 && u.bits.man != 0);
 }
 
-#ifdef LONG_DOUBLE
+#ifdef OPENLIBM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __isnanl(long double e)
 {

--- a/src/s_isnormal.c
+++ b/src/s_isnormal.c
@@ -49,7 +49,7 @@ __isnormalf(float f)
 	return (u.bits.exp != 0 && u.bits.exp != 255);
 }
 
-#ifdef OPENLIBM_LONG_DOUBLE
+#ifdef OLM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __isnormall(long double e)
 {

--- a/src/s_isnormal.c
+++ b/src/s_isnormal.c
@@ -49,7 +49,7 @@ __isnormalf(float f)
 	return (u.bits.exp != 0 && u.bits.exp != 255);
 }
 
-#ifdef LONG_DOUBLE
+#ifdef OPENLIBM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __isnormall(long double e)
 {

--- a/src/s_nexttowardf.c
+++ b/src/s_nexttowardf.c
@@ -20,7 +20,7 @@
 
 #define	LDBL_INFNAN_EXP	(LDBL_MAX_EXP * 2 - 1)
 
-#ifdef OPENLIBM_LONG_DOUBLE
+#ifdef OLM_LONG_DOUBLE
 OLM_DLLEXPORT float
 nexttowardf(float x, long double y)
 {

--- a/src/s_nexttowardf.c
+++ b/src/s_nexttowardf.c
@@ -20,7 +20,7 @@
 
 #define	LDBL_INFNAN_EXP	(LDBL_MAX_EXP * 2 - 1)
 
-#ifdef LONG_DOUBLE
+#ifdef OPENLIBM_LONG_DOUBLE
 OLM_DLLEXPORT float
 nexttowardf(float x, long double y)
 {

--- a/src/s_signbit.c
+++ b/src/s_signbit.c
@@ -49,7 +49,7 @@ __signbitf(float f)
 	return (u.bits.sign);
 }
 
-#ifdef LONG_DOUBLE
+#ifdef OPENLIBM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __signbitl(long double e)
 {

--- a/src/s_signbit.c
+++ b/src/s_signbit.c
@@ -49,7 +49,7 @@ __signbitf(float f)
 	return (u.bits.sign);
 }
 
-#ifdef OPENLIBM_LONG_DOUBLE
+#ifdef OLM_LONG_DOUBLE
 OLM_DLLEXPORT int
 __signbitl(long double e)
 {


### PR DESCRIPTION
For some sad reason, gcc poisons LONG_DOUBLE in sreal.c. The identifier has been changed to OPENLIBM_LONG_DOUBLE