### PR TITLE
Fix weak reference macro redefinition in wasm32 target

### DIFF
--- a/src/cdefs-compat.h
+++ b/src/cdefs-compat.h
@@ -26,10 +26,8 @@
 #endif /* __strong_reference */
 
 #ifdef __wasm__
-#  define openlibm_weak_reference(sym,alias) openlibm_strong_reference(sym,alias)
-#endif
-
-#if defined(__weak_alias) && defined(__NetBSD__)
+#define openlibm_weak_reference(sym,alias) openlibm_strong_reference(sym,alias)
+#elif defined(__weak_alias) && defined(__NetBSD__)
 #define openlibm_weak_reference(sym,alias) __weak_alias(alias,sym)
 #elif defined(__weak_reference)
 #define openlibm_weak_reference(sym,alias) __weak_reference(sym,alias)


### PR DESCRIPTION
The recent fixes for NetBSD caused a macro redefinition for `openlibm_weak_reference` when building with `ARCH=wasm32`.
Fix by connecting to the condition chain.