### PR TITLE
Refactor: OLM_DLLEXPORT definition now lives in a standalone header.

### DIFF
--- a/include/openlibm_defs.h
+++ b/include/openlibm_defs.h
@@ -1,0 +1,14 @@
+#ifndef OPENLIBM_DEFS_H_
+#define OPENLIBM_DEFS_H_
+
+#ifdef _WIN32
+# ifdef IMPORT_EXPORTS
+#  define OLM_DLLEXPORT __declspec(dllimport)
+# else
+#  define OLM_DLLEXPORT __declspec(dllexport)
+# endif
+#else
+#define OLM_DLLEXPORT __attribute__ ((visibility("default")))
+#endif
+
+#endif // OPENLIBM_DEFS_H_

--- a/include/openlibm_fenv_amd64.h
+++ b/include/openlibm_fenv_amd64.h
@@ -29,10 +29,9 @@
 #ifndef	_FENV_H_
 #define	_FENV_H_
 
+#include <openlibm_defs.h>
 #include "cdefs-compat.h"
 #include "types-compat.h"
-
-#include "math_private.h"
 
 #ifndef	__fenv_static
 #define	__fenv_static	static

--- a/include/openlibm_math.h
+++ b/include/openlibm_math.h
@@ -18,6 +18,8 @@
 #include <math.h>
 #else /* !OPENLIBM_USE_HOST_MATH_H */
 
+#include <openlibm_defs.h>
+
 #ifndef OPENLIBM_MATH_H
 #define	OPENLIBM_MATH_H
 
@@ -31,16 +33,6 @@
 
 #ifndef __pure2
 #define __pure2
-#endif
-
-#ifdef _WIN32
-# ifdef IMPORT_EXPORTS
-#  define OLM_DLLEXPORT __declspec(dllimport)
-# else
-#  define OLM_DLLEXPORT __declspec(dllexport)
-# endif
-#else
-#define OLM_DLLEXPORT __attribute__ ((visibility("default")))
 #endif
 
 /*

--- a/src/math_private.h
+++ b/src/math_private.h
@@ -18,7 +18,7 @@
 #define	_MATH_PRIVATE_H_
 
 #include <openlibm_complex.h>
-
+#include <openlibm_defs.h>
 #include "cdefs-compat.h"
 #include "types-compat.h"
 #include "fpmath.h"
@@ -354,17 +354,5 @@ float complex __ldexp_cexpf(float complex,int);
 long double __kernel_sinl(long double, long double, int);
 long double __kernel_cosl(long double, long double);
 long double __kernel_tanl(long double, long double, int);
-
-#undef OLM_DLLEXPORT
-#ifdef _WIN32
-# ifdef IMPORT_EXPORTS
-#  define OLM_DLLEXPORT __declspec(dllimport)
-# else
-#  define OLM_DLLEXPORT __declspec(dllexport)
-# endif
-#else
-#define OLM_DLLEXPORT __attribute__ ((visibility("default")))
-#endif
-
 
 #endif /* !_MATH_PRIVATE_H_ */


### PR DESCRIPTION
On x86_64, openlibm_fenv.h is silently coupled to openlibm_complex.h due to the inclusion of math_private.h inside of openlibm_fenv_amd64.h. The math_private.h header was included to gain access to the OLM_DLLEXPORT macro. However, this macro is redefined, since it is originally defined in openlibm_math.h. This inclusion also exposes math_private.h to public clients, which is undesirable.

Instead, a standalone header is created to contain the OLM_DLLEXPORT definition. This header is used included in the appropriate files. openlibm_fenv_amd64.h is no longer coupled to math_private.h.

Resolves #191 