### PR TITLE
Replace a few remaining __strong_reference uses

### DIFF
--- a/src/cdefs-compat.h
+++ b/src/cdefs-compat.h
@@ -21,7 +21,7 @@
 #define openlibm_strong_reference(sym,aliassym) openlibm_weak_reference(sym,aliassym)
 #else
 #define openlibm_strong_reference(sym,aliassym)	\
-	OLM_DLLEXPORT extern __typeof (sym) aliassym __attribute__ ((__alias__ (#sym)));
+	OLM_DLLEXPORT extern __typeof (aliassym) aliassym __attribute__ ((__alias__ (#sym)));
 #endif /* __APPLE__ */
 #endif /* __strong_reference */
 

--- a/src/s_cacos.c
+++ b/src/s_cacos.c
@@ -50,6 +50,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 double complex
 cacos(double complex z)
 {
@@ -61,5 +63,5 @@ cacos(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(cacosl, cacos);
+openlibm_strong_reference(cacos, cacosl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_cacosh.c
+++ b/src/s_cacosh.c
@@ -46,6 +46,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 double complex
 cacosh(double complex z)
 {
@@ -56,5 +58,5 @@ cacosh(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(cacoshl, cacosh);
+openlibm_strong_reference(cacosh, cacoshl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_casin.c
+++ b/src/s_casin.c
@@ -53,6 +53,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 double complex
 casin(double complex z)
 {
@@ -130,5 +132,5 @@ casin(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(casinl, casin);
+openlibm_strong_reference(casin, casinl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_casinh.c
+++ b/src/s_casinh.c
@@ -46,6 +46,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 double complex
 casinh(double complex z)
 {
@@ -56,5 +58,5 @@ casinh(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(casinhl, casinh);
+openlibm_strong_reference(casinh, casinhl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_catan.c
+++ b/src/s_catan.c
@@ -66,6 +66,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 #define MAXNUM 1.0e308
 
 static const double DP1 = 3.14159265160560607910E0;
@@ -127,5 +129,5 @@ ovrf:
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(catanl, catan);
+openlibm_strong_reference(catan, catanl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_catanh.c
+++ b/src/s_catanh.c
@@ -46,6 +46,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 double complex
 catanh(double complex z)
 {
@@ -56,5 +58,5 @@ catanh(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(catanhl, catanh);
+openlibm_strong_reference(catanh, catanhl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_clog.c
+++ b/src/s_clog.c
@@ -38,7 +38,7 @@
  * If z = x + iy, r = sqrt( x**2 + y**2 ),
  * then
  *       w = log(r) + i arctan(y/x).
- * 
+ *
  * The arctangent ranges from -PI to +PI.
  *
  *
@@ -58,6 +58,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 double complex
 clog(double complex z)
 {
@@ -73,5 +75,5 @@ clog(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(clogl, clog);
+openlibm_strong_reference(clog, clogl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_cpow.c
+++ b/src/s_cpow.c
@@ -74,5 +74,5 @@ cpow(double complex a, double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(cpowl, cpow);
+openlibm_strong_reference(cpow, cpowl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */


### PR DESCRIPTION
__strong_alias is an ELF feature that is not available on Darwin/MachO.
We have openlibm_strong_reference to paper over these differences,
but we weren't using it consistently. In particular, we were still
using it to define long double -> double aliases on platforms where
these are the same type (e.g. aarch64). This didn't used to matter,
because the only such platform we supported was always Linux and
thus ELF. This patch fixes these instances thus fixing the build
on Apple Silicon.