### PR TITLE
Export `fenv` functions on all platforms

### DIFF
--- a/amd64/fenv.c
+++ b/amd64/fenv.c
@@ -29,7 +29,7 @@
 #include "bsd_fpu.h"
 #include "math_private.h"
 
-#ifdef _WIN32
+#ifndef OPENLIBM_USE_HOST_FENV_H
 #define __fenv_static OLM_DLLEXPORT
 #endif
 #include <openlibm_fenv.h>


### PR DESCRIPTION
Win32 has been using a hack to switch the `fenv` functions from `static`
to `DLLEXPORT`, we apply that hack to all platforms that do not use a
host `fenv.h`.