### PR TITLE
Fix Apple Silicon build

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -55,6 +55,9 @@ $(error "the mingw32 compiler you are using fails the openblas testsuite. please
 endif
 
 # OS-specific stuff
+ifeq ($(ARCH),arm64)
+override ARCH := aarch64
+endif
 ifeq ($(findstring arm,$(ARCH)),arm)
 override ARCH := arm
 MARCH ?= armv7-a
@@ -144,6 +147,13 @@ CFLAGS_add += -I$(OPENLIBM_HOME)/ld128
 endif
 endif
 
+ifneq ($(filter $(ARCH),i387 amd64),)
+LONG_DOUBLE_NOT_DOUBLE := 1
+else ifeq ($(ARCH), aarch64)
+ifneq ($(OS),Darwin)
+LONG_DOUBLE_NOT_DOUBLE := 1
+endif
+endif
 
 %.c.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add) -c $< -o $@

--- a/Make.inc
+++ b/Make.inc
@@ -148,6 +148,9 @@ endif
 endif
 
 ifneq ($(filter $(ARCH),i387 amd64),)
+# Determines whether `long double` is the same as `double` on this arch.
+# linux x86_64, for instance, `long double` is 80 bits wide, whereas on macOS aarch64,
+# `long double` is the same as `double`. 
 LONG_DOUBLE_NOT_DOUBLE := 1
 else ifeq ($(ARCH), aarch64)
 ifneq ($(OS),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ OPENLIBM_HOME=$(abspath .)
 include ./Make.inc
 
 SUBDIRS = src $(ARCH) bsdsrc
+ifeq ($(LONG_DOUBLE_NOT_DOUBLE),1)
 # Add ld80 directory on x86 and x64
 ifneq ($(filter $(ARCH),i387 amd64),)
 SUBDIRS += ld80
@@ -9,6 +10,7 @@ else
 ifneq ($(filter $(ARCH),aarch64),)
 SUBDIRS += ld128
 else
+endif
 endif
 endif
 

--- a/src/Make.files
+++ b/src/Make.files
@@ -44,7 +44,7 @@ endif
 endif
 
 # Add in long double functions for x86, x64 and aarch64
-ifneq ($(filter $(ARCH),i387 amd64 aarch64),)
+ifeq ($(LONG_DOUBLE_NOT_DOUBLE),1)
 # C99 long double functions
 $(CUR_SRCS) +=	s_copysignl.c s_fabsl.c s_llrintl.c s_lrintl.c s_modfl.c
 


### PR DESCRIPTION
My previous Apple Silicon build went through, so I thought it already
worked, but it turns out it accidentally built an armv7 build instead.
This actually fixes the Apple Silicon build. One thing to note in
particular is that on Apple Silicong `long double` is the same as
`double` while on Linux `long double` is a 128 bit double-double
format.