### PR TITLE
Fix compilation errors on wasm32

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -29,17 +29,16 @@ USEGCC ?= 0
 USECLANG ?= 1
 endif
 
-AR ?= $(TOOLPREFIX)ar
-
 ifeq ($(ARCH),wasm32)
-CC ?= clang-8
-USEGCC ?= 0
-CFLAGS_add += -fno-builtin -fno-strict-aliasing
+USECLANG = 1
+TOOLPREFIX = llvm-
 endif
+
+AR ?= $(TOOLPREFIX)ar
 
 ifeq ($(USECLANG),1)
 USEGCC ?= 0
-CC ?= clang
+CC = clang
 CFLAGS_add += -fno-builtin -fno-strict-aliasing
 endif
 

--- a/include/openlibm_math.h
+++ b/include/openlibm_math.h
@@ -304,6 +304,7 @@ OLM_DLLEXPORT double	trunc(double);
  * BSD math library entry points
  */
 #if __BSD_VISIBLE
+OLM_DLLEXPORT int	isinff(float) __pure2;
 OLM_DLLEXPORT int	isnanf(float) __pure2;
 
 /*


### PR DESCRIPTION
Fixes missing declaration of `isinff` and invalid library creation due to the use of `ar` instead of `llvm-ar`.