### PR TITLE
Revert "Export `fenv` functions on all platforms (#213)"

### DIFF
--- a/amd64/fenv.c
+++ b/amd64/fenv.c
@@ -29,7 +29,7 @@
 #include "bsd_fpu.h"
 #include "math_private.h"
 
-#ifndef OPENLIBM_USE_HOST_FENV_H
+#ifdef _WIN32
 #define __fenv_static OLM_DLLEXPORT
 #endif
 #include <openlibm_fenv.h>


### PR DESCRIPTION
The implementation of `fesetenv` cannot be portable, as the value of
`FE_DFL_ENV` differs between platforms. On FreeBSD, it is a actual
environment. With glibc however, it's a sentinel -1 handled in the
implementation of its floating point functions.

https://github.com/freebsd/freebsd/blob/a41d904f70e8e9e3c3062952b52f0845af0af738/lib/msun/x86/fenv.h#L97-L99

https://github.com/bminor/glibc/blob/acdcca72940e060270e4e54d9c0457398110f409/sysdeps/x86/fpu/bits/fenv.h#L96-L97

With openlibm based on FreeBSD's libm, it assumes `FE_DFL_ENV` to be an
actual environment. That assumption breaks using code that was compiled
against glibc, e.g., `libcuda`:

```
Thread 1 "julia-debug" received signal SIGSEGV, Segmentation fault.
0x00007ffff7b855d0 in fesetenv () from /home/tim/Julia/julia/build/release/usr/bin/../lib/libopenlibm.so
(gdb) bt
```

This reverts commit 5a27b4c0c0a5befc2b7622ff8517743963c1f1d2.

Fixes https://github.com/JuliaLang/julia/issues/38427.