### PR TITLE
Make fenv methods static on additional platforms.

### DIFF
--- a/aarch64/fenv.c
+++ b/aarch64/fenv.c
@@ -26,7 +26,6 @@
  * $FreeBSD: src/lib/msun/arm/fenv.c,v 1.3 2011/10/16 05:37:56 das Exp $
  */
 
-#define	__fenv_static
 #include <openlibm_fenv.h>
 
 #ifdef __GNUC_GNU_INLINE__

--- a/powerpc/fenv.c
+++ b/powerpc/fenv.c
@@ -26,7 +26,6 @@
  * $FreeBSD$
  */
 
-#define	__fenv_static
 #include <openlibm_fenv.h>
 
 #ifdef __GNUC_GNU_INLINE__


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/issues/39462, https://github.com/JuliaLang/julia/pull/38466. Similarly to https://github.com/JuliaMath/openlibm/pull/219, this makes sure we don't export `fenv` routines on some additional platforms (being conservative here and only using those for which CUDA, which relies on this behavior, is available).