### PR TITLE
Replace remaining __strong_alias uses

### DIFF
--- a/src/s_cabs.c
+++ b/src/s_cabs.c
@@ -19,6 +19,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 double
 cabs(double complex z)
 {
@@ -26,5 +28,5 @@ cabs(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(cabsl, cabs);
+openlibm_strong_reference(cabs, cabsl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_ccos.c
+++ b/src/s_ccos.c
@@ -53,6 +53,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 /* calculate cosh and sinh */
 
 static void
@@ -85,5 +87,5 @@ ccos(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(ccosl, ccos);
+openlibm_strong_reference(ccos, ccosl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_csin.c
+++ b/src/s_csin.c
@@ -55,6 +55,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 /* calculate cosh and sinh */
 
 static void
@@ -87,5 +89,5 @@ csin(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(csinl, csin);
+openlibm_strong_reference(csin, csinl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */

--- a/src/s_ctan.c
+++ b/src/s_ctan.c
@@ -60,6 +60,8 @@
 #include <openlibm_complex.h>
 #include <openlibm_math.h>
 
+#include "math_private.h"
+
 #define MACHEP 1.1e-16
 #define MAXNUM 1.0e308
 
@@ -153,5 +155,5 @@ ctan(double complex z)
 }
 
 #if	LDBL_MANT_DIG == DBL_MANT_DIG
-__strong_alias(ctanl, ctan);
+openlibm_strong_reference(ctan, ctanl);
 #endif	/* LDBL_MANT_DIG == DBL_MANT_DIG */


### PR DESCRIPTION
Similar to earlier pull request #210.

For some reason a few uses of `__strong_alias` were still left.