### PR TITLE
Add missing aliases for 64-bit long double functions

### DIFF
--- a/bsdsrc/b_tgamma.c
+++ b/bsdsrc/b_tgamma.c
@@ -38,6 +38,7 @@
  * acknowledged.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "mathimpl.h"
@@ -312,3 +313,7 @@ neg_gam(x)
 	if (sgn < 0) y = -y;
 	return (M_PI / (y*z));
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(tgamma, tgammal);
+#endif

--- a/src/e_acosh.c
+++ b/src/e_acosh.c
@@ -29,6 +29,7 @@
  *	acosh(NaN) is NaN without signal.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -61,3 +62,7 @@ __ieee754_acosh(double x)
 	    return log1p(t+sqrt(2.0*t+t*t));
 	}
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(acosh, acoshl);
+#endif

--- a/src/e_atanh.c
+++ b/src/e_atanh.c
@@ -33,6 +33,7 @@
  *
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -61,3 +62,7 @@ __ieee754_atanh(double x)
 	    t = 0.5*log1p((x+x)/(one-x));
 	if(hx>=0) return t; else return -t;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(atanh, atanhl);
+#endif

--- a/src/e_cosh.c
+++ b/src/e_cosh.c
@@ -35,6 +35,7 @@
  *	only cosh(0)=1 is exact for finite x.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -78,3 +79,7 @@ __ieee754_cosh(double x)
     /* |x| > overflowthresold, cosh(x) overflow */
 	return huge*huge;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(cosh, coshl);
+#endif

--- a/src/e_exp.c
+++ b/src/e_exp.c
@@ -165,3 +165,7 @@ __ieee754_exp(double x)	/* default IEEE double exp */
 	    return y*twopk*twom1000;
 	}
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(exp, expl);
+#endif

--- a/src/e_log.c
+++ b/src/e_log.c
@@ -65,6 +65,7 @@
  * to produce the hexadecimal values shown.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -139,3 +140,7 @@ __ieee754_log(double x)
 		     return dk*ln2_hi-((s*(f-R)-dk*ln2_lo)-f);
 	}
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(log, logl);
+#endif

--- a/src/e_log10.c
+++ b/src/e_log10.c
@@ -22,6 +22,7 @@
  * in not-quite-routine extra precision.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -86,3 +87,7 @@ __ieee754_log10(double x)
 
 	return val_lo + val_hi;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(log10, log10l);
+#endif

--- a/src/e_log2.c
+++ b/src/e_log2.c
@@ -24,6 +24,7 @@
  * in not-quite-routine extra precision.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -109,3 +110,7 @@ __ieee754_log2(double x)
 
 	return val_lo + val_hi;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(log2, log2l);
+#endif

--- a/src/e_pow.c
+++ b/src/e_pow.c
@@ -57,6 +57,7 @@
  * to produce the hexadecimal values shown.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -310,3 +311,7 @@ __ieee754_pow(double x, double y)
 	else SET_HIGH_WORD(z,j);
 	return s*z;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(pow, powl);
+#endif

--- a/src/e_sinh.c
+++ b/src/e_sinh.c
@@ -32,6 +32,7 @@
  *	only sinh(0)=0 is exact for finite x.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -72,3 +73,7 @@ __ieee754_sinh(double x)
     /* |x| > overflowthresold, sinh(x) overflow */
 	return x*shuge;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(sinh, sinhl);
+#endif

--- a/src/s_asinh.c
+++ b/src/s_asinh.c
@@ -24,6 +24,7 @@
  *		 := sign(x)*log1p(|x| + x^2/(1 + sqrt(1+x^2)))
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -55,3 +56,7 @@ asinh(double x)
 	}
 	if(hx>0) return w; else return -w;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(asinh, asinhl);
+#endif

--- a/src/s_erf.c
+++ b/src/s_erf.c
@@ -107,6 +107,7 @@
  *	   	erfc/erf(NaN) is NaN
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -299,3 +300,8 @@ erfc(double x)
 	    if(hx>0) return tiny*tiny; else return two-tiny;
 	}
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(erf, erfl);
+openlibm_weak_reference(erfc, erfcl);
+#endif

--- a/src/s_expm1.c
+++ b/src/s_expm1.c
@@ -215,3 +215,7 @@ expm1(double x)
 	}
 	return y;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(expm1, expm1l);
+#endif

--- a/src/s_log1p.c
+++ b/src/s_log1p.c
@@ -173,3 +173,7 @@ log1p(double x)
 	if(k==0) return f-(hfsq-s*(hfsq+R)); else
 		 return k*ln2_hi-((hfsq-(s*(hfsq+R)+(k*ln2_lo+c)))-f);
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(log1p, log1pl);
+#endif

--- a/src/s_tanh.c
+++ b/src/s_tanh.c
@@ -37,6 +37,7 @@
  *	only tanh(0)=0 is exact for finite argument.
  */
 
+#include <float.h>
 #include <openlibm_math.h>
 
 #include "math_private.h"
@@ -76,3 +77,7 @@ tanh(double x)
 	}
 	return (jx>=0)? z: -z;
 }
+
+#if (LDBL_MANT_DIG == 53)
+openlibm_weak_reference(tanh, tanhl);
+#endif


### PR DESCRIPTION
Some standard `long double` functions declared in `openlibm_math.h` do not have an implementation in `src`, so they are essentially missing on platforms where `long double` is a `double`.

Specifically, `acoshl`, `asinhl`, `atanhl`, `coshl`, `erfcl`, `erfl`, `expl`, `expm1l`, `log10l`, `log1pl`, `log2l`, `logl`, `powl`, `sinhl`, `tanhl`, and `tgammal`.

This PR uses the `openlibm_weak_reference()` mechanism to define them in terms of the `double`-based version. I'm not certain this is the best approach, but it seems worth a try. I have checked in a cross-compiling environment that all the target functions are exposed and functional.