### PR TITLE
prefix symbols with _ for 32-bit x86 Windows

### DIFF
--- a/src/cdefs-compat.h
+++ b/src/cdefs-compat.h
@@ -73,7 +73,7 @@
     __asm__(".weak_reference openlibm_symbol_prefix/**/alias");\
     __asm__(".set openlibm_symbol_prefix/**/alias, openlibm_symbol_prefix/**/sym")
 #endif
-#undef oepnlibm_symbol_prefix
+#undef openlibm_symbol_prefix
 #else	/* !__ELF__ */
 #ifdef __STDC__
 #define openlibm_weak_reference(sym,alias)	\

--- a/src/cdefs-compat.h
+++ b/src/cdefs-compat.h
@@ -59,15 +59,21 @@
 #endif	/* __warn_references */
 #endif	/* __STDC__ */
 #elif defined(__clang__) /* CLANG */
+#if defined(_WIN32) && defined (_X86_)
+#define openlibm_symbol_prefix "_"
+#else
+#define openlibm_symbol_prefix ""
+#endif
 #ifdef __STDC__
 #define openlibm_weak_reference(sym,alias)     \
-    __asm__(".weak_reference " #alias); \
-    __asm__(".set " #alias ", " #sym)
+    __asm__(".weak_reference " openlibm_symbol_prefix #alias); \
+    __asm__(".set " openlibm_symbol_prefix #alias ", " openlibm_symbol_prefix #sym)
 #else
 #define openlibm_weak_reference(sym,alias)     \
-    __asm__(".weak_reference alias");\
-    __asm__(".set alias, sym")
+    __asm__(".weak_reference openlibm_symbol_prefix/**/alias");\
+    __asm__(".set openlibm_symbol_prefix/**/alias, openlibm_symbol_prefix/**/sym")
 #endif
+#undef oepnlibm_symbol_prefix
 #else	/* !__ELF__ */
 #ifdef __STDC__
 #define openlibm_weak_reference(sym,alias)	\


### PR DESCRIPTION
In a case that I believe can only be hit for Clang i686-*-windows-gnu (AKA MinGW), symbols in asm need to be prefixed with `_`.  Fixes #237