### PR TITLE
msys2 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: OpenLibm CI
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.sys}}
-          install: mingw-w64-${{matrix.env}}-toolchain
+          install: base-devel mingw-w64-${{matrix.env}}-toolchain
       - name: Build and run tests
         shell: msys2 {0}
         run: make && make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-nix:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -15,19 +15,12 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
         arch:
           - x64
           - x86
           - armv7
           - aarch64
         exclude:
-          - os: windows-latest
-            arch: aarch64
-          - os: windows-latest
-            arch: armv7
-          - os: windows-latest
-            arch: x86
           - os: macos-latest
             arch: armv7
           - os: macos-latest
@@ -35,17 +28,26 @@ jobs:
             
     steps:
       - uses: actions/checkout@v2
-      - name: Install i686-w64-mingw32-gcc
-        if: ${{ matrix.os == 'windows-latest' && matrix.arch == 'x86' }}
-        shell: bash
-        run: |
-          choco install mingw -y --x86 --force --params "/exception:sjlj"
-          choco install make -y
-          echo "CC=i686-w64-mingw32-gcc" >> "${GITHUB_ENV}"
-      - name: Set compiler for 64-bit Windows
-        if: ${{ matrix.os == 'windows-latest' && matrix.arch == 'x64' }}
-        shell: bash
-        run: |
-          echo "CC=x86_64-w64-mingw32-gcc" >> "${GITHUB_ENV}"
       - name: Build and run tests
+        run: make && make test
+
+  build-msys2:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: mingw64, env: x86_64 }
+          - { sys: mingw32, env: i686 }
+          - { sys: ucrt64,  env: ucrt-x86_64 }  # Experimental!
+          - { sys: clang64, env: clang-x86_64 } # Experimental!
+            
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          install: mingw-w64-${{matrix.env}}-toolchain
+      - name: Build and run tests
+        shell: msys2 {0}
         run: make && make test

--- a/Make.inc
+++ b/Make.inc
@@ -94,8 +94,7 @@ endif
 #keep these if statements separate
 ifeq ($(OS), WINNT)
 SHLIB_EXT = dll
-SONAME_FLAG = -soname
-CFLAGS_add += -nodefaultlibs
+SONAME_FLAG =
 shlibdir = $(bindir)
 else
 ifeq ($(OS), Darwin)

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ else
 OLM_MAJOR_MINOR_SHLIB_EXT := $(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
 OLM_MAJOR_SHLIB_EXT := $(SHLIB_EXT).$(SOMAJOR)
 endif
+LDFLAGS_add += -Wl,$(SONAME_FLAG),libopenlibm.$(OLM_MAJOR_SHLIB_EXT)
 endif
 
 .PHONY: all check test clean distclean \
@@ -67,7 +68,7 @@ libopenlibm.a: $(OBJS)
 	$(AR) -rcs libopenlibm.a $(OBJS)
 
 libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT): $(OBJS)
-	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -Wl,$(SONAME_FLAG),libopenlibm.$(OLM_MAJOR_SHLIB_EXT) -o $@
+	$(CC) -shared $(OBJS) $(LDFLAGS) $(LDFLAGS_add) -o $@
 ifneq ($(OS),WINNT)
 	ln -sf $@ libopenlibm.$(OLM_MAJOR_SHLIB_EXT)
 	ln -sf $@ libopenlibm.$(SHLIB_EXT)

--- a/include/openlibm_fenv_i387.h
+++ b/include/openlibm_fenv_i387.h
@@ -88,8 +88,8 @@ __BEGIN_DECLS
 
 /* After testing for SSE support once, we cache the result in __has_sse. */
 enum __sse_support { __SSE_YES, __SSE_NO, __SSE_UNK };
-extern enum __sse_support __has_sse;
-int __test_sse(void);
+OLM_DLLEXPORT extern enum __sse_support __has_sse;
+OLM_DLLEXPORT int __test_sse(void);
 #ifdef __SSE__
 #define	__HAS_SSE()	1
 #else
@@ -98,7 +98,7 @@ int __test_sse(void);
 #endif
 
 /* Default floating-point environment */
-extern const fenv_t	__fe_dfl_env;
+OLM_DLLEXPORT extern const fenv_t	__fe_dfl_env;
 #define	FE_DFL_ENV	(&__fe_dfl_env)
 
 #define	__fldcw(__cw)		__asm __volatile("fldcw %0" : : "m" (__cw))
@@ -150,8 +150,8 @@ fegetexceptflag(fexcept_t *__flagp, int __excepts)
 	return (0);
 }
 
-int fesetexceptflag(const fexcept_t *__flagp, int __excepts);
-int feraiseexcept(int __excepts);
+OLM_DLLEXPORT int fesetexceptflag(const fexcept_t *__flagp, int __excepts);
+OLM_DLLEXPORT int feraiseexcept(int __excepts);
 
 __fenv_static inline int
 fetestexcept(int __excepts)
@@ -206,8 +206,8 @@ fesetround(int __round)
 	return (0);
 }
 
-int fegetenv(fenv_t *__envp);
-int feholdexcept(fenv_t *__envp);
+OLM_DLLEXPORT int fegetenv(fenv_t *__envp);
+OLM_DLLEXPORT int feholdexcept(fenv_t *__envp);
 
 __fenv_static inline int
 fesetenv(const fenv_t *__envp)
@@ -231,12 +231,12 @@ fesetenv(const fenv_t *__envp)
 	return (0);
 }
 
-int feupdateenv(const fenv_t *__envp);
+OLM_DLLEXPORT int feupdateenv(const fenv_t *__envp);
 
 #if __BSD_VISIBLE
 
-int feenableexcept(int __mask);
-int fedisableexcept(int __mask);
+OLM_DLLEXPORT int feenableexcept(int __mask);
+OLM_DLLEXPORT int fedisableexcept(int __mask);
 
 /* We currently provide no external definition of fegetexcept(). */
 static inline int

--- a/include/openlibm_fenv_i387.h
+++ b/include/openlibm_fenv_i387.h
@@ -29,6 +29,7 @@
 #ifndef	_FENV_H_
 #define	_FENV_H_
 
+#include "openlibm_defs.h"
 #include "cdefs-compat.h"
 #include "types-compat.h"
 

--- a/include/openlibm_math.h
+++ b/include/openlibm_math.h
@@ -174,7 +174,7 @@ extern const union __nan_un {
 #define	MAXFLOAT	((float)3.40282346638528860e+38)
 
 #ifndef OPENLIBM_ONLY_THREAD_SAFE
-extern int signgam;
+OLM_DLLEXPORT extern int signgam;
 #endif
 #endif /* __BSD_VISIBLE || __XSI_VISIBLE */
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,6 +7,8 @@ ifneq ($(OS),WINNT)
 ifneq ($(OS),Darwin)
 OPENLIBM_LIB += -Wl,-rpath=$(OPENLIBM_HOME)
 endif
+else # WINNT
+CFLAGS_add += -DIMPORT_EXPORTS
 endif
 
 all: test-double test-float # test-double-system test-float-system


### PR DESCRIPTION
Adds a separate job using setup-msys2 to test all currently available MinGW-w64 environments there.

These currently fail a few tests relating to signgam from lgamma.  I'm not sure if that's due to it calling mingw-w64's variant of lgamma or what.