### PR TITLE
CI (Windows): set `msys2 {0}` as the default shell for all Windows steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           - { sys: mingw32, env: i686 }
           - { sys: ucrt64,  env: ucrt-x86_64 }  # Experimental!
           - { sys: clang64, env: clang-x86_64 } # Experimental!
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
       - uses: actions/checkout@v2
       - name: Set up the desired MSYS2 environment
@@ -48,6 +51,4 @@ jobs:
           msystem: ${{matrix.sys}}
           install: base-devel mingw-w64-${{matrix.env}}-toolchain
       - run: make
-        shell: msys2 {0}
       - run: make test
-        shell: msys2 {0}


### PR DESCRIPTION
cc: @jeremyd2019 