### PR TITLE
Bump version to 0.8

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -6,8 +6,8 @@ default: all
 OS := $(shell uname)
 # Do not forget to bump SOMINOR when changing VERSION,
 # and SOMAJOR when breaking ABI in a backward-incompatible way
-VERSION = 0.7.0
-SOMAJOR = 3
+VERSION = 0.8.0
+SOMAJOR = 4
 SOMINOR = 0
 DESTDIR =
 prefix ?= /usr/local


### PR DESCRIPTION
Bump version to 0.8 since we now have working CI now, with proper platform support, arm64 on win, and assorted fixes.

Bump the SOVERSION as well since we have some new exports and such.