### PR TITLE
[Windows] install import library to libdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,13 @@ install-static: libopenlibm.a
 
 install-shared: libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT)
 	mkdir -p $(DESTDIR)$(shlibdir)
+ifeq ($(OS), WINNT)
+	mkdir -p $(DESTDIR)$(libdir)
+	cp -RpP -f libopenlibm.*$(SHLIB_EXT) $(DESTDIR)$(shlibdir)/
+	cp -RpP -f libopenlibm.*$(SHLIB_EXT).a $(DESTDIR)$(libdir)/
+else
 	cp -RpP -f libopenlibm.*$(SHLIB_EXT)* $(DESTDIR)$(shlibdir)/
+endif
 
 install-pkgconfig: openlibm.pc
 	mkdir -p $(DESTDIR)$(pkgconfigdir)


### PR DESCRIPTION
import libraries need to go in libdir (`/lib`), while dlls need to be on the PATH so need to be installed to shlibdir (`/bin`)

This hunk was overlooked from MINGW-packages' patch, noticed when opening msys2/MINGW-packages#9560