### PR TITLE
Another Windows ARM64 fix

### DIFF
--- a/src/aarch64_fpmath.h
+++ b/src/aarch64_fpmath.h
@@ -25,7 +25,7 @@
  * SUCH DAMAGE.
  *
  * $FreeBSD: head/lib/libc/aarch64/_fpmath.h 281197 2015-04-07 09:52:14Z andrew $
-*/
+ */
 
 #include <stdint.h>
 

--- a/src/aarch64_fpmath.h
+++ b/src/aarch64_fpmath.h
@@ -25,7 +25,9 @@
  * SUCH DAMAGE.
  *
  * $FreeBSD: head/lib/libc/aarch64/_fpmath.h 281197 2015-04-07 09:52:14Z andrew $
- */
+*/
+
+#include <stdint.h>
 
 union IEEEl2bits {
 	long double	e;


### PR DESCRIPTION
include stdint.h to be sure that uint64_t can be used.
This header already had references to uint32_t, so I assumed it was safe to use those typedefs, but a compile error revealed it was not always.