### PR TITLE
Remove non-working www subdomain from OpenLibm

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
         <h2>
 <a id="openlibm" class="anchor" href="#openlibm" aria-hidden="true"><span class="octicon octicon-link"></span></a>OpenLibm</h2>
 
-<p><a href="http://www.openlibm.org">OpenLibm</a> is an effort to have a high quality, portable, standalone
+<p><a href="http://openlibm.org">OpenLibm</a> is an effort to have a high quality, portable, standalone
 C mathematical library (<a href="http://en.wikipedia.org/wiki/libm"><code>libm</code></a>).
 It can be used standalone in applications and programming language
 implementations.</p>


### PR DESCRIPTION
The self-referential link to http://www.openlibm.org is non-functional. Remove the `www`.