### PR TITLE
Restore original fdlibm copyright on sincos files

### DIFF
--- a/src/s_sincos.c
+++ b/src/s_sincos.c
@@ -1,5 +1,14 @@
 /* @(#)s_sincos.c 5.1 13/07/15 */
-/*
+/* See openlibm LICENSE.md for full license details.
+ *
+ * ====================================================
+ * This file is derived from fdlibm:
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ *
  * ====================================================
  * Copyright (C) 2013 Elliot Saba. All rights reserved.
  *
@@ -25,7 +34,7 @@
  *      Borrow liberally from s_sin.c and s_cos.c, merging
  *  efforts where applicable and returning their values in
  * appropriate variables, thereby slightly reducing the
- * amount of work relative to just calling sin/cos(x) 
+ * amount of work relative to just calling sin/cos(x)
  * separately
  *
  * Special cases:

--- a/src/s_sincosf.c
+++ b/src/s_sincosf.c
@@ -1,5 +1,14 @@
 /* s_sincosf.c -- float version of s_sincos.c
  *
+ * ====================================================
+ * This file is derived from fdlibm:
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ *
+ * ====================================================
  * Copyright (C) 2013 Elliot Saba
  * Developed at the University of Washington
  *
@@ -115,14 +124,14 @@ sincosf(float x, float * s, float * c) {
 	/* |x| ~<= 9*pi/4 */
 	if(ix<=0x40e231d5) {
 		/* |x|  ~> 7*pi/4 */
-	    if(ix<=0x40afeddf) {	
+	    if(ix<=0x40afeddf) {
 			if(hx>0) {
 				__kernel_sincosdf( x - sc3pio2, c, &k_s );
 				*s = -k_s;
 			} else {
 				__kernel_sincosdf( x + sc3pio2, &k_c, s );
 				*c = -k_c;
-		    } 
+		    }
 		}
 		else {
 	    	if( hx > 0 ) {
@@ -148,7 +157,7 @@ sincosf(float x, float * s, float * c) {
 			case 1:
 				__kernel_sincosdf( -y, c, s );
 				break;
-			case 2: 
+			case 2:
 				__kernel_sincosdf( -y, s, &k_c);
 				*c = -k_c;
 				break;


### PR DESCRIPTION
These files are derived from the original fdlibm sin/cos files. While we do already preserve that license notice in LICENSE.md (so there's no actual license compliance issue here), it's cleaner to have the copyright notice in the file as well, in case somebody copies the file out of the repo.

Fixes #264 