### PR TITLE
Fix Apple PowerPC build

### DIFF
--- a/include/openlibm_fenv.h
+++ b/include/openlibm_fenv.h
@@ -8,7 +8,7 @@
 #include <openlibm_fenv_amd64.h>
 #elif defined(__i386__)
 #include <openlibm_fenv_i387.h>
-#elif defined(__powerpc__)
+#elif defined(__powerpc__) || defined(__ppc__)
 #include <openlibm_fenv_powerpc.h>
 #elif defined(__mips__)
 #include <openlibm_fenv_mips.h>

--- a/src/fpmath.h
+++ b/src/fpmath.h
@@ -37,7 +37,7 @@
 #else 
 #include "i386_fpmath.h"
 #endif
-#elif defined(__powerpc__)
+#elif defined(__powerpc__) || defined(__ppc__)
 #include "powerpc_fpmath.h"
 #elif defined(__mips__)
 #include "mips_fpmath.h"


### PR DESCRIPTION
Apple versions of GCC define __ppc__ instead of __powerpc__

Fixes #275