### PR TITLE
build: fix pkgconfig cflags and libdir variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,9 @@ clean:
 	$(MAKE) -C test clean
 
 openlibm.pc: openlibm.pc.in Make.inc Makefile
-	echo "prefix=${prefix}" > openlibm.pc
-	echo "version=${VERSION}" >> openlibm.pc
+	echo "version=${VERSION}" > openlibm.pc
+	echo "libdir=$(DESTDIR)$(libdir)" >> openlibm.pc
+	echo "includedir=$(DESTDIR)$(includedir)/openlibm" >> openlibm.pc
 	cat openlibm.pc.in >> openlibm.pc
 
 install-static: libopenlibm.a

--- a/openlibm.pc.in
+++ b/openlibm.pc.in
@@ -1,7 +1,3 @@
-exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
-
 Name: openlibm
 Version: ${version}
 URL: https://github.com/JuliaMath/openlibm


### PR DESCRIPTION
This patch makes the pkgconfig file respect prefix directory overrides.