### PR TITLE
test: add target to gen coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,15 @@ jobs:
           install: base-devel mingw-w64-${{matrix.env}}-toolchain
       - run: make
       - run: make test
+  code-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
+      - name: Build and Run tests
+        run: make coverage -j
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./cov-html/libopenlibm.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: ./cov-html/libopenlibm.info
+      - uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: ./cov-html/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 *.so*
 *.dylib*
 *.pc
+
+# code coverage
+cov-html/
+*.gcda
+*.gcno

--- a/Make.inc
+++ b/Make.inc
@@ -21,6 +21,9 @@ else
 pkgconfigdir ?= $(libdir)/pkgconfig
 endif
 
+# Build with Code Coverage
+CODE_COVERAGE ?= 0
+
 USEGCC ?= 1
 USECLANG ?= 0
 
@@ -161,6 +164,12 @@ ifeq ($(filter $(OS),Darwin WINNT),)
 LONG_DOUBLE_NOT_DOUBLE := 1
 endif
 endif
+
+ifeq ($(CODE_COVERAGE),1)
+CFLAGS_add  += -g -O0 --coverage
+LDFLAGS_add += --coverage
+endif # CODE_COVERAGE==1
+
 
 %.c.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(CFLAGS_add) -c $< -o $@

--- a/Make.inc
+++ b/Make.inc
@@ -22,6 +22,10 @@ pkgconfigdir ?= $(libdir)/pkgconfig
 endif
 
 # Build with Code Coverage
+# Only test with Ubuntu + gcc + lcov, may not work for other platform.
+# deps:  https://github.com/linux-test-project/lcov
+# You don't need to set this flag manually, `make coverage` will do it for you.
+# Just Run:  make clean && make coverage -j
 CODE_COVERAGE ?= 0
 
 USEGCC ?= 1

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,12 @@ COVERAGE_FILE:=$(COVERAGE_DIR)/libopenlibm.info
 coverage: clean-coverage
 	mkdir $(COVERAGE_DIR)
 	$(MAKE) test  CODE_COVERAGE=1
-	lcov -d amd64 -d bsdsrc -d ld80 -d src --capture --output-file $(COVERAGE_FILE)
-	genhtml --output-directory $(COVERAGE_DIR)/ $(COVERAGE_FILE)
+	lcov -d amd64 -d bsdsrc -d ld80 -d src \
+		--rc lcov_branch_coverage=1 --capture --output-file $(COVERAGE_FILE)
+	genhtml --legend --branch-coverage \
+		--title "Openlibm commit `git rev-parse HEAD`" \
+		--output-directory $(COVERAGE_DIR)/ \
+		$(COVERAGE_FILE)
 
 # Zero coverage statistics and Delete report
 clean-coverage:

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,25 @@ test/test-double: libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT)
 test/test-float: libopenlibm.$(OLM_MAJOR_MINOR_SHLIB_EXT)
 	$(MAKE) -C test test-float
 
-clean:
+COVERAGE_DIR:=cov-html
+COVERAGE_FILE:=$(COVERAGE_DIR)/libopenlibm.info
+# Gen cov report with:  make clean && make coverage -j
+coverage: clean-coverage
+	mkdir $(COVERAGE_DIR)
+	$(MAKE) test  CODE_COVERAGE=1
+	lcov -d amd64 -d bsdsrc -d ld80 -d src --capture --output-file $(COVERAGE_FILE)
+	genhtml --output-directory $(COVERAGE_DIR)/ $(COVERAGE_FILE)
+
+# Zero coverage statistics and Delete report
+clean-coverage:
+	-lcov -d amd64 -d bsdsrc -d ld80 -d src --zerocounters
+	rm -f ./*/*.gcda
+	rm -rf $(COVERAGE_DIR)/
+
+clean: clean-coverage
 	rm -f aarch64/*.o amd64/*.o arm/*.o bsdsrc/*.o i387/*.o loongarch64/*.o ld80/*.o ld128/*.o src/*.o powerpc/*.o mips/*.o s390/*.o riscv64/*.o
 	rm -f libopenlibm.a libopenlibm.*$(SHLIB_EXT)*
+	rm -f ./*/*.gcno
 	$(MAKE) -C test clean
 
 openlibm.pc: openlibm.pc.in Make.inc Makefile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenLibm
 
+[![codecov](https://codecov.io/gh/JuliaMath/openlibm/graph/badge.svg?token=eTAdN7d9cg)](https://codecov.io/gh/JuliaMath/openlibm)
+
 [OpenLibm](https://openlibm.org/) is an effort to have a high quality, portable, standalone
 C mathematical library ([`libm`](http://en.wikipedia.org/wiki/libm)).
 It can be used standalone in applications and programming language


### PR DESCRIPTION
Part of #290

- [x] Add `make coverage` 
- [x] Setup CI, upload HTML cov report
- [x] Upload cov report to coveralls or other online ci service