### PR TITLE
Minor fix-ups for Darwin PowerPC

### DIFF
--- a/include/openlibm_fenv.h
+++ b/include/openlibm_fenv.h
@@ -8,7 +8,7 @@
 #include <openlibm_fenv_amd64.h>
 #elif defined(__i386__)
 #include <openlibm_fenv_i387.h>
-#elif defined(__powerpc__) || defined(__ppc__)
+#elif defined(__powerpc__) || defined(__POWERPC__)
 #include <openlibm_fenv_powerpc.h>
 #elif defined(__mips__)
 #include <openlibm_fenv_mips.h>

--- a/include/openlibm_fenv_powerpc.h
+++ b/include/openlibm_fenv_powerpc.h
@@ -97,7 +97,7 @@ extern const fenv_t	__fe_dfl_env;
 union __fpscr {
 	double __d;
 	struct {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 		fenv_t __reg;
 		__uint32_t __junk;
 #else

--- a/src/fpmath.h
+++ b/src/fpmath.h
@@ -37,7 +37,7 @@
 #else 
 #include "i386_fpmath.h"
 #endif
-#elif defined(__powerpc__) || defined(__ppc__)
+#elif defined(__powerpc__) || defined(__POWERPC__)
 #include "powerpc_fpmath.h"
 #elif defined(__mips__)
 #include "mips_fpmath.h"


### PR DESCRIPTION
@ViralBShah This took forever :) Sorry for a ridiculous delay, it was forgotten.

Here are two tiny fixes:

1. Use a macro which includes `ppc64`, so that it is not left broken on macOS. (BTW, this still leaves out AIX, I believe?)
2. Make sure `__BYTE_ORDER__` is actually defined: AFAIK, it may not be the case with some old gcc versions, and those support C99, so it is relevant.