### PR TITLE
Add stack markings for GNU to fmod assembly files

### DIFF
--- a/amd64/e_fmod.S
+++ b/amd64/e_fmod.S
@@ -49,3 +49,8 @@ ENTRY(fmod)
 	fstp	%st
 	ret
 END(fmod)
+
+/* Enable stack protection */
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/e_fmodf.S
+++ b/amd64/e_fmodf.S
@@ -19,3 +19,8 @@ ENTRY(fmodf)
 	fstp	%st
 	ret
 END(fmodf)
+
+/* Enable stack protection */
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/amd64/e_fmodl.S
+++ b/amd64/e_fmodl.S
@@ -45,3 +45,8 @@ ENTRY(fmodl)
 	fstp	%st(1)
 	ret
 END(fmodl)
+
+/* Enable stack protection */
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
This adds stack markings to the missing fmod .S files, otherwise the final libopenlibm object file gets marked with an executable stack.

Output when compiling from source on Gentoo Linux:

```
 * QA Notice: The following files contain writable and executable sections
 *  Files with such sections will not work properly (or at all!) on some
 *  architectures/operating systems.  A bug should be filed at
 *  https://bugs.gentoo.org/ to make sure the issue is fixed.
 *  For more information, see:
 *
 *    https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
 *
 *  Please include the following list of files in your report:
 *  Note: Bugs should be filed for the respective maintainers
 *  of the package in question and not hardened@gentoo.org.
 * RWX --- --- usr/lib64/libopenlibm.so.4.0
```