### PR TITLE
Fix fenv_t initializer

### DIFF
--- a/loongarch64/fenv.c
+++ b/loongarch64/fenv.c
@@ -1,5 +1,5 @@
 #define	__fenv_static
-#include <fenv.h>
+#include <openlibm_fenv.h>
 
 #ifdef __GNUC_GNU_INLINE__
 #error "This file must be compiled with C99 'inline' semantics"

--- a/riscv64/fenv.c
+++ b/riscv64/fenv.c
@@ -27,7 +27,7 @@
  */
 
 #define	__fenv_static
-#include "fenv.h"
+#include <openlibm_fenv.h>
 
 #ifdef __GNUC_GNU_INLINE__
 #error "This file must be compiled with C99 'inline' semantics"


### PR DESCRIPTION
I have no idea why previous versions compile on GitHub actions, but they don't on my loongarch64 machine, and there was also someone reported on aarch64 architecture #278 . Initializer of a struct should be a brace-enclosed list. Btw, my gcc version is 14.2.1, it seems that cross-compile gcc version in GitHub actions is old.