### PR TITLE
ci: Fix clang build and Update qemu

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -46,7 +46,7 @@ jobs:
         run: make -C test ARCH=$ARCH TOOLPREFIX=$TRIPLE-
       - name: Run Tests
         env:
-          QEMU_EXEC: qemu-${{ matrix.config.arch }}-static
+          QEMU_EXEC: qemu-${{ matrix.config.arch }}
           CROSS_LIB: /usr/${{ matrix.config.triple }}
         run: |
           $QEMU_EXEC -L . -L $CROSS_LIB/  test/test-float

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -38,7 +38,7 @@ jobs:
         # this ensure install latest qemu on ubuntu, apt get version is old
         env:
           QEMU_SRC: "http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu"
-          QEMU_VER: "qemu-user-static_7\\.2+dfsg-.*_amd64.deb$"
+          QEMU_VER: "qemu-user-static_6\\.2+dfsg-.*_amd64.deb$"
         run: |
           DEB=`curl -s $QEMU_SRC/ | grep -o -E 'href="([^"#]+)"' | cut -d'"' -f2 | grep $QEMU_VER | tail -1`
           wget $QEMU_SRC/$DEB

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -11,7 +11,9 @@ on:
 
 jobs:
   build-cross-qemu:
-    runs-on: ubuntu-latest
+    # TODO: We need Ubuntu 24.04 to use newer version of qemu,
+    #   switch to ubuntu-latest when `ubuntu-latest >= 24.04`
+    runs-on: ubuntu-24.04
     name: build-cross-qemu-${{ matrix.config.arch }}
     strategy:
       fail-fast: false
@@ -34,19 +36,10 @@ jobs:
       TRIPLE: ${{ matrix.config.triple }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install QEMU
-        # this ensure install latest qemu on ubuntu, apt get version is old
-        env:
-          QEMU_SRC: "http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu"
-          QEMU_VER: "qemu-user-static_9.*_amd64.deb$"
-        run: |
-          DEB=`curl -s $QEMU_SRC/ | grep -o -E 'href="([^"#]+)"' | cut -d'"' -f2 | grep $QEMU_VER | tail -1`
-          wget $QEMU_SRC/$DEB
-          sudo dpkg -i $DEB
-      - name: Install toolchain gcc-${{ matrix.config.triple }}
+      - name: Install qemu and toolchain gcc-${{ matrix.config.triple }}
         run: |
           sudo apt update
-          sudo apt install gcc-$TRIPLE -y
+          sudo apt install qemu-user qemu-user-binfmt gcc-$TRIPLE -y
       - name: Build with ${{ matrix.config.triple }}-gcc
         run: make ARCH=$ARCH TOOLPREFIX=$TRIPLE-
       - name: Build tests

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -38,7 +38,7 @@ jobs:
         # this ensure install latest qemu on ubuntu, apt get version is old
         env:
           QEMU_SRC: "http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu"
-          QEMU_VER: "qemu-user-static_6\\.2+dfsg-.*_amd64.deb$"
+          QEMU_VER: "qemu-user-static_9.*_amd64.deb$"
         run: |
           DEB=`curl -s $QEMU_SRC/ | grep -o -E 'href="([^"#]+)"' | cut -d'"' -f2 | grep $QEMU_VER | tail -1`
           wget $QEMU_SRC/$DEB

--- a/Make.inc
+++ b/Make.inc
@@ -37,6 +37,12 @@ USEGCC ?= 0
 USECLANG ?= 1
 endif
 
+ifneq (,$(findstring CLANG,$(MSYSTEM)))
+# In MSYS2
+USEGCC = 0
+USECLANG = 1
+endif
+
 ifeq ($(ARCH),wasm32)
 USECLANG = 1
 USEGCC = 0


### PR DESCRIPTION
- [x] Install `qemu` by `apt` on `ubuntu-24.04`
	ref: https://github.com/libuv/libuv/pull/4630
- [x] Fix clang build on Windows
	> The active environment is selected via the `MSYSTEM` environment variable
	> https://www.msys2.org/docs/environments/