### PR TITLE
Add Codecov token to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./cov-html/libopenlibm.info
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report


### PR DESCRIPTION
Coverage hasn't been properly submitted in a long time. The issue as reported by the CI job is that we need a token, so I've added one in the repository settings and this commit just tells the action to use it.