### PR TITLE
Fix BSD-specific types on Linux for aarch64

### DIFF
--- a/aarch64/fenv.c
+++ b/aarch64/fenv.c
@@ -36,7 +36,7 @@
  * Hopefully the system ID byte is immutable, so it's valid to use
  * this as a default environment.
  */
-const fenv_t __fe_dfl_env = 0;
+const fenv_t __fe_dfl_env = {0};
 
 extern inline int feclearexcept(int __excepts);
 extern inline int fegetexceptflag(fexcept_t *__flagp, int __excepts);

--- a/include/openlibm_fenv_aarch64.h
+++ b/include/openlibm_fenv_aarch64.h
@@ -36,8 +36,8 @@
 #endif
 
 /* The high 32 bits contain fpcr, low 32 contain fpsr. */
-typedef	__uint64_t	fenv_t;
-typedef	__uint64_t	fexcept_t;
+typedef	uint64_t	fenv_t;
+typedef	uint64_t	fexcept_t;
 
 /* Exception flags */
 #define	FE_INVALID	0x00000001
@@ -158,8 +158,8 @@ fesetround(int __round)
 __fenv_static inline int
 fegetenv(fenv_t *__envp)
 {
-	__uint64_t fpcr;
-	__uint64_t fpsr;
+	uint64_t fpcr;
+	uint64_t fpsr;
 
 	__mrs_fpcr(fpcr);
 	__mrs_fpsr(fpsr);
@@ -179,7 +179,7 @@ feholdexcept(fenv_t *__envp)
 	__msr_fpcr(__r);
 
 	__mrs_fpsr(__r);
-	*__envp |= (__uint32_t)__r;
+	*__envp |= (uint32_t)__r;
 	__r &= ~(_ENABLE_MASK);
 	__msr_fpsr(__r);
 	return (0);
@@ -190,7 +190,7 @@ fesetenv(const fenv_t *__envp)
 {
 
 	__msr_fpcr((*__envp) >> 32);
-	__msr_fpsr((fenv_t)(__uint32_t)*__envp);
+	__msr_fpsr((fenv_t)(uint32_t)*__envp);
 	return (0);
 }
 


### PR DESCRIPTION
## Problem

The recent addition of aarch64 fenv support in #319 (commit 1eeb139) introduced BSD-specific types (`__uint64_t` and `__uint32_t`) that are not defined on Linux systems. This causes compilation failures on aarch64-linux targets.

## Solution

This PR replaces BSD-specific types with standard C99 types:
- `__uint64_t` → `uint64_t`
- `__uint32_t` → `uint32_t`

These standard types are available on all platforms through the included `<stdint.h>` header.

Additionally, this fixes the initialization of `__fe_dfl_env` from scalar `0` to `{0}` to match the typedef as a non-scalar type.

## Testing

Tested successfully with BinaryBuilder.jl on:
- aarch64-linux-gnu
- i686-linux-musl
- Other Linux platforms

This resolves the build failures reported in JuliaPackaging/Yggdrasil#11347

## Changes

- Replace all instances of `__uint64_t` with `uint64_t` in `include/openlibm_fenv_aarch64.h`
- Replace all instances of `__uint32_t` with `uint32_t` in `include/openlibm_fenv_aarch64.h`
- Fix initialization of `__fe_dfl_env` in `aarch64/fenv.c` from `= 0` to `= {0}`