### PR TITLE
Musl compatibility fixes for s390 and powerpc

### DIFF
--- a/include/openlibm_fenv_powerpc.h
+++ b/include/openlibm_fenv_powerpc.h
@@ -29,14 +29,15 @@
 #ifndef	_FENV_H_
 #define	_FENV_H_
 
+#include <stdint.h>
 #include <sys/types.h>
 
 #ifndef	__fenv_static
 #define	__fenv_static	static
 #endif
 
-typedef	__uint32_t	fenv_t;
-typedef	__uint32_t	fexcept_t;
+typedef	uint32_t	fenv_t;
+typedef	uint32_t	fexcept_t;
 
 /* Exception flags */
 #define	FE_INEXACT	0x02000000
@@ -99,9 +100,9 @@ union __fpscr {
 	struct {
 #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 		fenv_t __reg;
-		__uint32_t __junk;
+		uint32_t __junk;
 #else
-		__uint32_t __junk;
+		uint32_t __junk;
 		fenv_t __reg;
 #endif
 	} __bits;

--- a/include/openlibm_fenv_powerpc.h
+++ b/include/openlibm_fenv_powerpc.h
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 #include <sys/types.h>
+#include "cdefs-compat.h"
 
 #ifndef	__fenv_static
 #define	__fenv_static	static

--- a/include/openlibm_fenv_s390.h
+++ b/include/openlibm_fenv_s390.h
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 #include <sys/types.h>
+#include "cdefs-compat.h"
 
 #ifndef	__fenv_static
 #define	__fenv_static	static

--- a/include/openlibm_fenv_s390.h
+++ b/include/openlibm_fenv_s390.h
@@ -29,14 +29,15 @@
 #ifndef	_FENV_H_
 #define	_FENV_H_
 
+#include <stdint.h>
 #include <sys/types.h>
 
 #ifndef	__fenv_static
 #define	__fenv_static	static
 #endif
 
-typedef	__uint32_t	fenv_t;
-typedef	__uint32_t	fexcept_t;
+typedef	uint32_t	fenv_t;
+typedef	uint32_t	fexcept_t;
 
 /* Exception flags */
 #define	FE_INEXACT	0x080000


### PR DESCRIPTION
`__uint32_t` and `__BEGIN_DECLS` aren't standard so slight modifications are needed when they aren't provided by the libc