### PR TITLE
ci: add native ARM (Linux + Windows) and Intel macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,23 +45,6 @@ jobs:
           install: base-devel mingw-w64-${{matrix.env}}-toolchain
       - run: make
       - run: make test
-  code-coverage-old:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Setup LCOV
-        uses: hrishikesh-kadam/setup-lcov@v1
-      - name: Build and Run tests
-        run: make coverage -j
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v6
-      #   with:
-      #     files: ./cov-html/libopenlibm.info
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: actions/upload-artifact@v7
-        with:
-          name: code-coverage-report-old
-          path: ./cov-html/
   code-coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,16 @@ jobs:
       - run: make
       - run: make test
   windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { sys: mingw64, env: x86_64 }
-          - { sys: mingw32, env: i686 }
-          - { sys: ucrt64,  env: ucrt-x86_64 }  # Experimental!
-          - { sys: clang64, env: clang-x86_64 } # Experimental!
+          - { os: windows-latest,  sys: mingw64,     env: x86_64 }
+          - { os: windows-latest,  sys: mingw32,     env: i686 }
+          - { os: windows-latest,  sys: ucrt64,      env: ucrt-x86_64 }  # Experimental!
+          - { os: windows-latest,  sys: clang64,     env: clang-x86_64 } # Experimental!
+          - { os: windows-11-arm,  sys: clangarm64,  env: clang-aarch64 } # Experimental!
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-latest
+          - macos-15-intel
     steps:
       - uses: actions/checkout@v6
       - run: make


### PR DESCRIPTION
## Summary
- Adds `ubuntu-24.04-arm` to the `test-unix` matrix for native aarch64 Linux coverage (previously only via QEMU cross-compile in `cross.yml`).
- Adds `macos-15-intel` to keep explicit Intel macOS coverage now that `macos-latest` is Apple Silicon.

## Test plan
- [x] CI runs `make` + `make test` on `ubuntu-24.04-arm` and `macos-15-intel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)