### PR TITLE
riscv: allow single-precision float ABI (lp64f / ilp32f)

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -66,3 +66,35 @@ jobs:
           QEMU_LD_PREFIX: /usr/${{ matrix.config.triple }}
           LD_LIBRARY_PATH: .
         run: make test ARCH=$ARCH TOOLPREFIX=$TRIPLE- ${CC:+CC=$CC} ${AR:+AR=$AR}
+
+  # Regression test for #262 / #349: the RISC-V single-float ABI (lp64f /
+  # ilp32f) used to be rejected by include/openlibm_fenv_riscv.h with an
+  # `#error`. This job rebuilds the whole library with `-mabi=lp64f` to make
+  # sure the header (and the rest of openlibm) accepts that ABI.
+  #
+  # This is a COMPILE-ONLY check (build the static libopenlibm.a, no qemu run).
+  # Ubuntu's gcc-riscv64-linux-gnu ships only the default lp64d sysroot, so a
+  # full shared-library link or a qemu execution under lp64f is impossible
+  # without a custom single-float sysroot the distro does not provide. Building
+  # the static archive needs no libc/CRT link, so it compiles every source file
+  # (including riscv64/fenv.c, which pulls in the fixed header) under the
+  # single-float ABI and directly regresses the removed `#error`. Adding a
+  # bespoke lp64f sysroot would be exactly the kind of fragile, unmaintainable
+  # toolchain dependency that got mips64 disabled in #347, so we deliberately
+  # avoid it.
+  build-cross-riscv64-lp64f:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    name: build-cross-riscv64-lp64f
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install RISC-V toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-riscv64-linux-gnu
+      - name: Build libopenlibm.a for the single-float ABI (lp64f)
+        run: |
+          make -j$(nproc) ARCH=riscv64 TOOLPREFIX=riscv64-linux-gnu- \
+            CFLAGS_arch='-march=rv64imafc -mabi=lp64f' \
+            SFLAGS_arch='-march=rv64imafc -mabi=lp64f' \
+            libopenlibm.a

--- a/include/openlibm_fenv_riscv.h
+++ b/include/openlibm_fenv_riscv.h
@@ -74,12 +74,9 @@ __BEGIN_DECLS
 extern const fenv_t	__fe_dfl_env;
 #define	FE_DFL_ENV	(&__fe_dfl_env)
 
-#if !defined(__riscv_float_abi_soft) && !defined(__riscv_float_abi_double)
-#if defined(__riscv_float_abi_single)
-#error single precision floating point ABI not supported
-#else
+#if !defined(__riscv_float_abi_soft) && !defined(__riscv_float_abi_double) && \
+    !defined(__riscv_float_abi_single)
 #error compiler did not set soft/hard float macros
-#endif
 #endif
 
 #ifndef __riscv_float_abi_soft


### PR DESCRIPTION
## Summary
Fixes #262. The RISC-V fenv header rejected `__riscv_float_abi_single` (lp64f, ilp32f) with an \`#error\`, but the rejection isn't warranted: the F and D extensions share the same \`fcsr\` / \`fflags\` CSRs. The hard-float inline implementations below the guard use only \`csrr\`/\`csrw\`/\`csrc\` on those CSRs, all of which are present whenever F is present.

So lp64f / ilp32f can use the existing hard-float code path unchanged.

\`\`\`diff
-#if !defined(__riscv_float_abi_soft) && !defined(__riscv_float_abi_double)
-#if defined(__riscv_float_abi_single)
-#error single precision floating point ABI not supported
-#else
+#if !defined(__riscv_float_abi_soft) && !defined(__riscv_float_abi_double) && \
+    !defined(__riscv_float_abi_single)
 #error compiler did not set soft/hard float macros
 #endif
-#endif
\`\`\`

## Test plan
- [ ] CI green (no behavior change for existing `double` ABI users; lp64f users no longer hit the \`#error\`).
- [ ] If a future native riscv lp64f CI matrix entry lands, openlibm-test should pass there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)