### PR TITLE
Fix expm1l() returning NaN for large finite arguments (#306)

### DIFF
--- a/ld80/s_expm1l.c
+++ b/ld80/s_expm1l.c
@@ -57,6 +57,8 @@
  *
  */
 
+#include <float.h>
+
 #include <openlibm_math.h>
 
 static const long double MAXLOGL = 1.1356523406294143949492E4L;
@@ -131,8 +133,17 @@ qx = x + (0.5 * xx + xx * px / qx);
 
 /* exp(x) = exp(k ln 2) exp(remainder ln 2) = 2^k exp(remainder ln 2).
    We have qx = exp(remainder ln 2) - 1, so
-   exp(x) - 1  =  2^k (qx + 1) - 1  =  2^k qx + 2^k - 1.  */
-px = ldexpl(1.0L, k);
-x = px * qx + (px - 1.0);
+   exp(x) - 1  =  2^k (qx + 1) - 1  =  2^k qx + 2^k - 1.
+
+   For large k, 2^k overflows even though the final result is finite
+   (the argument is just below the overflow threshold).  In that regime
+   form exp(remainder ln 2) = qx + 1 first (which lies near 1) and scale
+   the exponent directly, so no intermediate value overflows.  */
+if (k >= LDBL_MAX_EXP) {
+  x = scalbnl(qx + 1.0L, k) - 1.0L;
+} else {
+  px = ldexpl(1.0L, k);
+  x = px * qx + (px - 1.0);
+}
 return x;
 }

--- a/test/regression/test-306.c
+++ b/test/regression/test-306.c
@@ -1,0 +1,50 @@
+/*
+ * Regression test for issue #306: expm1l overflows internally and returns NaN
+ * for large arguments that are still below the overflow threshold.
+ * https://github.com/JuliaMath/openlibm/issues/306
+ *
+ * For x just below MAXLOG the true result is finite (near LDBL_MAX), but the
+ * old reconstruction formed 2^k (with k == LDBL_MAX_EXP) which overflowed to
+ * +Inf; the subsequent (+Inf) + (-Inf) yielded NaN.  The fix scales the
+ * exponent of exp(remainder) directly in that regime.
+ *
+ * The expected hex values below are bit-for-bit what the system glibc expm1l
+ * returns on x86-64 (LDBL_MANT_DIG == 64).  Only meaningful for the 80-bit
+ * long double format, so skip elsewhere.
+ */
+#include <float.h>
+#include <math.h>
+
+#include "regress-util.h"
+
+int
+main(void)
+{
+	/*
+	 * Target the x86 80-bit long double path only: that is the code this fix
+	 * changes, and the only format for which the exact hex value below holds.
+	 * openlibm provides long double routines only on x86 and (linux) aarch64,
+	 * so every other format must compile to a bare skip with no reference to
+	 * expm1l (it may be absent from the library, breaking the link).
+	 */
+#if LDBL_MANT_DIG != 64
+	return REGRESS_SKIP;
+#else
+	long double x = 0x2.c5c85fdf170c604cp+12l;	/* ~11346.6, just below threshold */
+	long double y = expm1l(x);
+
+	/* Must be a large finite value, not NaN/Inf.  isnan() is type-generic;
+	   isnanl is a glibc-only symbol that would not link on macOS. */
+	CHECK(!isnan(y));
+	CHECK(isfinite(y));
+	CHECK(y > 0.0L);
+
+	/* Exact value matching glibc. */
+	CHECK(y == 0xf.ffffcfce79e56d5p+16380l);
+
+	/* A slightly larger argument must still overflow to +Inf. */
+	CHECK(isinf(expm1l(11357.0L)) == 1);
+
+	return 0;
+#endif
+}


### PR DESCRIPTION
Fixes #306.

`expm1l(0x2.c5c85fdf170c604cp+12L)` (x ≈ 11346.6) returned `NaN`; the true result is finite, near `LDBL_MAX` (`0xf.ffffcfce79e56d5p+16380L`), which glibc returns.

## Root cause
In `ld80/s_expm1l.c` the large-argument reconstruction is:
```c
px = ldexpl(1.0L, k);          /* k reaches 16384 == LDBL_MAX_EXP here */
x  = px * qx + (px - 1.0);
```
When `k == LDBL_MAX_EXP`, `ldexpl(1, k)` overflows to `+Inf`. The reduced remainder is negative (`qx = exp(rem)-1 < 0`), so `(+Inf)*(neg) + (+Inf-1) = -Inf + Inf = NaN`, even though the true value is finite.

## Fix
When `k >= LDBL_MAX_EXP`, build `exp(rem) = qx + 1` (a value near 1) and scale the exponent directly, avoiding the intermediate `2^k`:
```c
if (k >= LDBL_MAX_EXP)
    x = scalbnl(qx + 1.0L, k) - 1.0L;
else { px = ldexpl(1.0L, k); x = px*qx + (px - 1.0); }
```
Algebraically identical to the original; the normal path is untouched.

## Verification
- Reproducer now equals glibc **bit-for-bit**; a slightly larger x overflows to `+Inf` at the same point glibc does.
- Threshold walk (11355…11357) and assorted small/mid values (1e-10, 1.0, −5.0, 700.0) all match glibc.
- Full `make test` passes.
- New `test/regression/test-306.c` asserts finiteness + the exact glibc value + overflow above threshold; **fails before**, **passes after** (skips where `long double == double`).

Stacked on the regression-harness PR #350.