### PR TITLE
tgamma: raise FE_OVERFLOW instead of FE_DIVBYZERO on overflow (#325)

### DIFF
--- a/bsdsrc/b_tgamma.c
+++ b/bsdsrc/b_tgamma.c
@@ -131,7 +131,14 @@ tgamma(x)
 
 	if (isgreaterequal(x, 6)) {
 		if(x > 171.63)
-			return (x / zero);
+			/*
+			 * Overflow: the true value exceeds DBL_MAX.  Return +Inf
+			 * and raise FE_OVERFLOW (per math_errhandling ==
+			 * MATH_ERREXCEPT and the function comment above).  The
+			 * old `x / zero` returned +Inf but wrongly raised
+			 * FE_DIVBYZERO, which is reserved for the pole at x == 0.
+			 */
+			return (x * 0x1p1023);
 		u = large_gam(x);
 		return(__exp__D(u.a, u.b));
 	} else if (isgreaterequal(x, 1.0 + LEFT + x0))

--- a/test/regression/test-325.c
+++ b/test/regression/test-325.c
@@ -1,0 +1,65 @@
+/*
+ * Regression test for issue #325: tgamma() error signaling.
+ * https://github.com/JuliaMath/openlibm/issues/325
+ *
+ * openlibm reports math errors via FP exception flags, not errno
+ * (math_errhandling == MATH_ERREXCEPT).  tgamma already raised FE_DIVBYZERO at
+ * the pole (x == +-0) and FE_INVALID for negative-integer (domain) arguments,
+ * but overflow for large x went through `x / zero`, which returns +Inf while
+ * wrongly raising FE_DIVBYZERO instead of FE_OVERFLOW.  This pins the correct,
+ * glibc-matching exception for every error class.
+ *
+ * FP exception flags are emulated unreliably by qemu-user on some arches (see
+ * #347), so the test first checks that the environment tracks a plain
+ * divide-by-zero and skips if it does not.
+ */
+#include <math.h>
+#include <openlibm_fenv.h>
+
+#include "regress-util.h"
+
+static int
+fenv_tracks_flags(void)
+{
+	volatile double z = 0.0, r;
+
+	feclearexcept(FE_ALL_EXCEPT);
+	r = 1.0 / z;			/* a known divide-by-zero */
+	(void)r;
+	return fetestexcept(FE_DIVBYZERO) != 0;
+}
+
+static int
+raises(double x, int excepts)
+{
+	feclearexcept(FE_ALL_EXCEPT);
+	(void)tgamma(x);
+	return fetestexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW) == excepts;
+}
+
+int
+main(void)
+{
+	if (!fenv_tracks_flags())
+		return REGRESS_SKIP;
+
+	/* Pole at x == +-0: +-Inf, FE_DIVBYZERO. */
+	CHECK(isinf(tgamma(0.0)) == 1);
+	CHECK(raises(0.0, FE_DIVBYZERO));
+	CHECK(isinf(tgamma(-0.0)) == -1);
+	CHECK(raises(-0.0, FE_DIVBYZERO));
+
+	/* Negative integer (domain error): NaN, FE_INVALID. */
+	CHECK(isnan(tgamma(-2.0)));
+	CHECK(raises(-2.0, FE_INVALID));
+
+	/* Overflow for large finite x: +Inf, FE_OVERFLOW (was FE_DIVBYZERO). */
+	CHECK(isinf(tgamma(200.0)) == 1);
+	CHECK(raises(200.0, FE_OVERFLOW));
+
+	/* In-range result raises none of these. */
+	CHECK(tgamma(5.0) == 24.0);
+	CHECK(raises(5.0, 0));
+
+	return 0;
+}


### PR DESCRIPTION
Resolves #325 in a way consistent with the rest of openlibm.

**Background.** The issue asked for `errno` (ERANGE/EDOM). But openlibm reports math errors via **FP exception flags, not errno** — `include/openlibm_math.h` hardcodes `math_errhandling == MATH_ERREXCEPT`, and **no** function in the library sets `errno`. So the consistent fix is to ensure the correct *exceptions* are raised, not to introduce errno.

**What was actually wrong.** Auditing `tgamma`'s exceptions against glibc, only one case was incorrect:

| input | result | openlibm before | openlibm after / glibc |
|---|---|---|---|
| pole `x = ±0` | ±Inf | `FE_DIVBYZERO` ✓ | `FE_DIVBYZERO` |
| negative integer | NaN | `FE_INVALID` ✓ | `FE_INVALID` |
| **overflow `x > 171.63`** | +Inf | **`FE_DIVBYZERO`** ✗ | **`FE_OVERFLOW`** |
| in-range | finite | none ✓ | none |

The overflow path returned `x / zero` — +Inf, but raising **divide-by-zero**, a flag reserved for the pole. The function's own comment already says it should *"return +Inf and raise overflow."*

**Fix.** Replace `x / zero` with `x * 0x1p1023`, which overflows to +Inf and raises `FE_OVERFLOW`. One line; the pole and domain cases were already correct and are untouched. No errno.

**Test.** `test/regression/test-325.c` checks the exception flag for every error class. FP-exception flags are emulated unreliably by qemu-user on some arches (cf. #347), so it first verifies the environment tracks a plain divide-by-zero and skips if not. Verified: fails before / passes after; passes on x86, arm and riscv64 under qemu; green on the gcc-13/clang-18 `-Werror` lanes.