### PR TITLE
ci: speed up Windows jobs by trimming the msys2 install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Install only what the build needs instead of `base-devel` plus the
+        # full `*-toolchain` meta-package. The msys2 package cache is already on
+        # by default and hits, but pacman still *extracts* every package on each
+        # run, and base-devel + the toolchain meta dominate setup time (it was
+        # ~3.5 min of pacman install on the arm runner). openlibm only needs make
+        # and a C compiler: the -gcc package pulls in binutils/runtime, while the
+        # clang environments have no standalone binutils package so they keep the
+        # toolchain meta (for ar/lld).
         include:
-          - { os: windows-latest,  sys: mingw64,     env: x86_64 }
-          - { os: windows-latest,  sys: mingw32,     env: i686 }
-          - { os: windows-latest,  sys: ucrt64,      env: ucrt-x86_64 }  # Experimental!
-          - { os: windows-latest,  sys: clang64,     env: clang-x86_64 } # Experimental!
-          - { os: windows-11-arm,  sys: clangarm64,  env: clang-aarch64 } # Experimental!
+          - { os: windows-latest,  sys: mingw64,     install: "make mingw-w64-x86_64-gcc" }
+          - { os: windows-latest,  sys: mingw32,     install: "make mingw-w64-i686-gcc" }
+          - { os: windows-latest,  sys: ucrt64,      install: "make mingw-w64-ucrt-x86_64-gcc" }        # Experimental!
+          - { os: windows-latest,  sys: clang64,     install: "make mingw-w64-clang-x86_64-toolchain" }  # Experimental!
+          - { os: windows-11-arm,  sys: clangarm64,  install: "make mingw-w64-clang-aarch64-toolchain" } # Experimental!
     defaults:
       run:
         shell: msys2 {0}
@@ -49,7 +57,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.sys}}
-          install: base-devel mingw-w64-${{matrix.env}}-toolchain
+          install: ${{matrix.install}}
       - run: make -j$(nproc)
       - run: make test
   strict-warnings:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,18 @@ jobs:
         # Install only what the build needs instead of `base-devel` plus the
         # full `*-toolchain` meta-package. The msys2 package cache is already on
         # by default and hits, but pacman still *extracts* every package on each
-        # run, and base-devel + the toolchain meta dominate setup time (it was
+        # run, and base-devel + the toolchain meta dominated setup time (it was
         # ~3.5 min of pacman install on the arm runner). openlibm only needs make
-        # and a C compiler: the -gcc package pulls in binutils/runtime, while the
-        # clang environments have no standalone binutils package so they keep the
-        # toolchain meta (for ar/lld).
+        # and a C compiler. The -gcc package pulls in binutils and the runtime;
+        # the -clang package requires lld and llvm-tools (which provides ar), so
+        # it is a complete toolchain on its own without the meta-package's unused
+        # extras (lldb, openmp, flang, ...).
         include:
           - { os: windows-latest,  sys: mingw64,     install: "make mingw-w64-x86_64-gcc" }
           - { os: windows-latest,  sys: mingw32,     install: "make mingw-w64-i686-gcc" }
-          - { os: windows-latest,  sys: ucrt64,      install: "make mingw-w64-ucrt-x86_64-gcc" }        # Experimental!
-          - { os: windows-latest,  sys: clang64,     install: "make mingw-w64-clang-x86_64-toolchain" }  # Experimental!
-          - { os: windows-11-arm,  sys: clangarm64,  install: "make mingw-w64-clang-aarch64-toolchain" } # Experimental!
+          - { os: windows-latest,  sys: ucrt64,      install: "make mingw-w64-ucrt-x86_64-gcc" }    # Experimental!
+          - { os: windows-latest,  sys: clang64,     install: "make mingw-w64-clang-x86_64-clang" }  # Experimental!
+          - { os: windows-11-arm,  sys: clangarm64,  install: "make mingw-w64-clang-aarch64-clang" } # Experimental!
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
The Windows jobs are slow in setup, not build. On the windows-11-arm `clangarm64` job the steps were:

| step | time |
|---|---|
| Set up MSYS2 environment | **318s** |
| make | 41s |
| make test | 12s |

The msys2 package **cache is already enabled by default and hits** (the log shows a 1.5 GB cache restore). The cost that remains is `pacman` *extracting/installing* the packages — ~3.5 min — which caching cannot avoid. We were installing `base-devel` (≈150 packages: autotools, perl, …) plus the full `mingw-w64-*-toolchain` meta.

This installs only what the build uses: `make` + a C compiler.
- gcc environments (mingw64/mingw32/ucrt64): `mingw-w64-<env>-gcc` pulls in binutils + runtime, so they drop both `base-devel` and the toolchain meta.
- clang environments (clang64/clangarm64): kept on the toolchain meta (no standalone binutils package provides `ar`/`lld`), but still drop `base-devel`.

Validated by the Windows CI on this PR (build + `make test` green on all five environments).