### PR TITLE
ci: make codecov coverage status informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# Coverage is advisory for openlibm, not a merge gate.
+#
+# The library has many defensive branches (overflow/underflow guards, NaN and
+# special-value paths) that the test suites do not always exercise, so a small
+# patch can legitimately add lines that no test hits.  Report coverage so it is
+# visible in review, but never fail the check on it.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Coverage is advisory for openlibm, not a merge gate.

The library has many defensive branches (overflow/underflow guards, NaN and special-value paths) that the test suites don't always exercise, so a small, correct patch can legitimately add lines no test hits (e.g. the over/underflow guards in #351/#356). This marks the codecov `project` and `patch` statuses `informational: true` — coverage is still reported for review, but no longer fails CI.

Branch protection has no required status checks, so codecov was already non-blocking; this just stops it showing red on otherwise-green PRs.